### PR TITLE
Pass --tags to "git describe" for @PARENT_TAG@

### DIFF
--- a/tar_scm
+++ b/tar_scm
@@ -402,7 +402,7 @@ get_version () {
   case "$MYSCM" in
     git)
       #version=`safe_run git show --pretty=format:"$MYFORMAT" | head -n 1`
-      MYFORMAT=${MYFORMAT/@PARENT_TAG@/$(git describe | cut -d"-" -f1)}
+      MYFORMAT=${MYFORMAT/@PARENT_TAG@/$(git describe --tags)}
       version=`safe_run git log -n1 --date=short --pretty=format:"$MYFORMAT"|sed 's@-@@g'`
       ;;
     svn)


### PR DESCRIPTION
We really only care about tags here. Example of the difference, with
python-novaclient, as of today:

$ git describe | cut -d"-" -f1
2.6.10
$ git describe --tags
2.10.0

That's because we also match lightweight tags now.
