### PR TITLE
Fixed support for including Git submodules.

### DIFF
--- a/tar_scm
+++ b/tar_scm
@@ -251,11 +251,6 @@ initial_clone () {
     git)
       # Clone with full depth; so that the revision can be found if specified
       safe_run git clone "$MYURL" "$CLONE_TO"
-      if [ "$USE_SUBMODULES" == "enable" ]; then
-        safe_run cd "$CLONE_TO"
-        safe_run git submodule update --init --recursive
-        safe_run cd ..
-      fi
       ;;
     svn)
       args=
@@ -360,6 +355,9 @@ switch_to_revision () {
         echo "$MYREVISION does not refer to a branch, not attempting git pull"
       else
         safe_run git pull
+      fi
+      if [ "$USE_SUBMODULES" == "enable" ]; then
+        safe_run git submodule update --init --recursive
       fi
       ;;
     svn|bzr)


### PR DESCRIPTION
The current handling of Git submodules in tar_scm is broken; submodules are revision-specific, but the submodule update happens before the correct revision has been checked out.  

I've added a simple fix that should address this issue, allowing submodules to be used when building any Git revision.
