### PR TITLE
Properly sanitize ISO-formatted dates for use in version strings

### DIFF
--- a/tar_scm
+++ b/tar_scm
@@ -396,6 +396,8 @@ detect_version () {
   TAR_VERSION="$MYPREFIX$version"
 }
 
+ISO_CLEANUP_RE='s@([0-9]{4})-([0-9]{2})-([0-9]{2}) +([0-9]{2})([:]([0-9]{2})([:]([0-9]{2}))?)?( +[-+][0-9]{3,4})?@\1\2\3T\4\6\8@g'
+
 get_version () {
   case "$MYSCM" in
     git)
@@ -407,7 +409,7 @@ get_version () {
               exit 1
           fi
       fi
-      version=`safe_run git log -n1 --date=short --pretty=format:"$MYFORMAT"|sed 's@-@@g'`
+      version=`safe_run git log -n1 --date=short --pretty=format:"$MYFORMAT" | sed -r -e "$ISO_CLEANUP_RE" -e 's@[-:]@@g'`
       ;;
     svn)
       #rev=`LC_ALL=C safe_run svn info | awk '/^Revision:/ { print $2 }'`
@@ -441,7 +443,7 @@ get_version () {
       # extract only the first value from the tuple, except for maybe
       # 'sub(...)' which is only available since 2.4 (first introduced
       # in openSUSE 12.3).
-      version=`safe_run hg log -l1 -r$rev --template "$MYFORMAT"|sed 's@-@@g'`
+      version=`safe_run hg log -l1 -r$rev --template "$MYFORMAT" | sed -r -e "$ISO_CLEANUP_RE" -e 's@[-:]@@g'`
       ;;
     bzr)
       #safe_run bzr log -l1 ...

--- a/tests/githgtests.py
+++ b/tests/githgtests.py
@@ -20,6 +20,10 @@ class GitHgTests(CommonTests):
         self.tar_scm_std('--versionformat', self.yyyymmdd_format)
         self.assertTarOnly(self.basename(version = self.dateYYYYMMDD(self.rev(2))))
 
+    def test_versionformat_dateYYYYMMDDHHMMSS(self):
+        self.tar_scm_std('--versionformat', self.yyyymmddhhmmss_format)
+        self.assertTarOnly(self.basename(version = self.dateYYYYMMDDHHMMSS(self.rev(2))))
+
     def _mixed_version_format(self):
         return self.mixed_version_template % (self.timestamp_format, self.abbrev_hash_format)
 

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -16,6 +16,7 @@ class GitTests(GitHgTests):
     abbrev_hash_format = '%h'
     timestamp_format   = '%ct'
     yyyymmdd_format    = '%cd'
+    yyyymmddhhmmss_format = '%ci'
 
     def default_version(self):
         return self.timestamps(self.rev(2))
@@ -29,6 +30,11 @@ class GitTests(GitHgTests):
     def dateYYYYMMDD(self, rev):
         dateobj = datetime.date.fromtimestamp(float(self.timestamps(rev)))
         return dateobj.strftime("%4Y%02m%02d")
+
+    # This comment line helps align lines with hgtests.py.
+    def dateYYYYMMDDHHMMSS(self, rev):
+        dateobj = datetime.datetime.fromtimestamp(float(self.timestamps(rev)))
+        return dateobj.strftime("%4Y%02m%02dT%02H%02M%02S")
 
     def rev(self, rev):
         f = self.fixtures

--- a/tests/hgtests.py
+++ b/tests/hgtests.py
@@ -15,6 +15,7 @@ class HgTests(GitHgTests):
     abbrev_hash_format = '{node|short}'
     timestamp_format   = '{date}'
     yyyymmdd_format    = '{date|shortdate}'
+    yyyymmddhhmmss_format = '{date|isodatesec}'
 
     def default_version(self):
         return self.rev(2)
@@ -28,3 +29,7 @@ class HgTests(GitHgTests):
     def dateYYYYMMDD(self, rev):
         dateobj = datetime.date.fromtimestamp(self.timestamps(rev)[0])
         return dateobj.strftime("%4Y%02m%02d")
+
+    def dateYYYYMMDDHHMMSS(self, rev):
+        dateobj = datetime.datetime.fromtimestamp(self.timestamps(rev)[0])
+        return dateobj.strftime("%4Y%02m%02dT%02H%02M%02S")


### PR DESCRIPTION
Tests pass, timezone normalization (to UTC) for some other day. Perhaps.
