### PR TITLE
versonformat: @REVISION@ for git

### DIFF
--- a/tar_scm
+++ b/tar_scm
@@ -16,6 +16,7 @@ set_default_params () {
   MYSCM=""
   MYURL=""
   MYVERSION="_auto_"
+  MYBASETAG=""
   MYFORMAT=""
   MYPREFIX=""
   MYFILENAME=""
@@ -107,6 +108,10 @@ parse_params () {
         CHANGES_AUTHOR="$2"
         shift
       ;;
+      --basetag)
+        MYBASETAG="$2"
+        shift
+        ;;
       *)
         echo "Unknown parameter: $1"
         echo 'Usage: $SERVICE --scm $SCM --url $URL [--subdir $SUBDIR] [--revision $REVISION] [--version $VERSION] [--include $INCLUDE]* [--exclude $EXCLUDE]* [--versionformat $FORMAT] [--versionprefix $PREFIX] [--filename $FILENAME] [--package-meta $META] [--submodules disable] --outdir $OUT'
@@ -564,6 +569,16 @@ get_version () {
   case "$MYSCM" in
     git)
       #version=`safe_run git show --pretty=format:"$MYFORMAT" | head -n 1`
+      if [[ "$MYFORMAT" =~ .*@REVISION@.* ]]; then
+          LREV=$(git describe --tags --long ${MYBASETAG:+--match="$MYBASETAG"})
+          if [[ "$?" -eq 0 ]]; then
+              LREV=$(echo "$LREV" | perl -pe 's{^.*-(\d+)-g\w+$}{$1}g')
+          else
+              LREV=$(git rev-list --count HEAD)
+          fi
+          MYFORMAT="${MYFORMAT/@REVISION@/$LREV}"
+          echo "MYFORMAT: $MYFORMAT"
+      fi
       if [[ "$MYFORMAT" =~ .*@PARENT_TAG@.*  ]] ; then
           PARENT_TAG=$(git describe --tags --abbrev=0)
           if [[ "$?" -gt 0 ]]; then

--- a/tar_scm.service
+++ b/tar_scm.service
@@ -19,6 +19,13 @@
   <param name="version">
     <description>Specify version to be used in tarball. Defaults to automatically detected value formatted by versionformat parameter.</description>
   </param>
+  <param name="basetag">
+    <description>Name of the git tag that equals the base version part of what
+    is actually being packaged.
+    For example, considering the obs-service-tar_scm repository itself, if
+    &lt;versionformat&gt;0.3.2+git@REVISION@&lt;/versionformat&gt; is set,
+    then the basetag would be v0.3.2.</description>
+  </param>
   <param name="versionformat">
     <description>
 	Auto-generate version from checked out source using this format
@@ -42,6 +49,9 @@
 	%h		Abbreviated hash, e.g. cc62c54
 
 	@PARENT_TAG@	the first tag that is reachable, e.g. v0.2.3
+
+	@REVISION@	the distance to the given base tag, or if no base tag
+			is given, the nearest tag
 
 	For hg, the value is passed to hg log --template=....  See the
 	hg documentation for more information.  The default is '{rev}'


### PR DESCRIPTION
git revision offset calculation has been implemented. this changes are from git://git.inai.de/obs-service-tar_scm

please, see for details:
http://lists.opensuse.org/opensuse-packaging/2014-01/msg00034.html
