### PR TITLE
Make.more

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,11 @@ SYSCFG   = /etc
 mylibdir = $(PREFIX)/lib/obs/service
 mycfgdir = $(SYSCFG)/obs/services
 
+.PHONY: check
+check:
+	: Running the test suite.  Please be patient - this takes a few minutes ...
+	python tests/test.py
+
 .PHONY: install
 install:
 	mkdir -p $(DESTDIR)$(mylibdir)


### PR DESCRIPTION
- the install target caters to the flexibility implied by the use of rpm macros in the `%install` section of the specfile.
- the `%check` section code is packaged as the `check` target in the makefile.
