### PR TITLE
Also retrieve tags for a cached git repo.

### DIFF
--- a/tar_scm
+++ b/tar_scm
@@ -111,6 +111,7 @@ FETCH_UPSTREAM_COMMANDS = {
 def update_cache_git(url, clone_dir, revision):
     """update sources from GIT"""
 
+    safe_run(['git', 'fetch', '--tags'], cwd=clone_dir, interactive=sys.stdout.isatty())
     safe_run(['git', 'fetch'], cwd=clone_dir, interactive=sys.stdout.isatty())
 
 


### PR DESCRIPTION
If someone refers to a tag in the revision field, git fetch might
not have necessarily pulled that object.

As documented, the safe way is to run git fetch _and_
git fetch --tags
