### PR TITLE
add @TAG_OFFSET@ support in versionformat for git

### DIFF
--- a/tar_scm.service
+++ b/tar_scm.service
@@ -30,18 +30,20 @@
       remove some unhelpful characters.  Here are some useful examples of
       strings which are expanded, see the git-log documentation for more.
 
-      %ct             Commit time as a UNIX timestamp, e.g. 1384855776.
-                      This is the default.
+      %ct               Commit time as a UNIX timestamp, e.g. 1384855776.
+                        This is the default.
 
-      %at             Author time as a UNIX timestamp, e.g. 1384855776.
+      %at               Author time as a UNIX timestamp, e.g. 1384855776.
 
-      %cd             Commit date in YYYYMMDD format, e.g. 20131119
+      %cd               Commit date in YYYYMMDD format, e.g. 20131119
 
-      %ad             Author date in YYYYMMDD format, e.g. 20131119
+      %ad               Author date in YYYYMMDD format, e.g. 20131119
 
-      %h              Abbreviated hash, e.g. cc62c54
+      %h                Abbreviated hash, e.g. cc62c54
 
-      @PARENT_TAG@    the first tag that is reachable, e.g. v0.2.3
+      @PARENT_TAG@      The first tag that is reachable, e.g. v0.2.3
+
+      @TAG_OFFSET@      The commit count since @PARENT_TAG@, e.g. 9
 
       For hg, the value is passed to hg log --template=....  See the
       hg documentation for more information.  The default is '{rev}'

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -70,6 +70,10 @@ class GitTests(GitHgTests):
         self.tar_scm_std('--versionformat', "@PARENT_TAG@.1")
         self.assertTarOnly(self.basename(version=self.rev(2)) + '.1')
 
+    def test_versionformat_tagoffset(self):
+        self.tar_scm_std('--versionformat', "@PARENT_TAG@.@TAG_OFFSET@")
+        self.assertTarOnly(self.basename(version=self.rev(2) + ".0"))
+
     def _submodule_fixture(self, submod_name):
         fix = self.fixtures
         repo_path = fix.repo_path


### PR DESCRIPTION
@TAG_OFFSET@ will mark the commit count since @PARENT_TAG@, and @SEQUENCE_NUMBER@ will mark the commit count since the first commit.


Well, previous pull request was closed incorrect by me, so another one is here.