### PR TITLE
Fix newline at the end of @PARENT_TAG@

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -367,8 +367,9 @@ def detect_version_git(repodir, versionformat):
 
     if re.match('.*@PARENT_TAG@.*', versionformat):
         try:
+            # strip to remove newlines
             text = safe_run(['git', 'describe', '--tags', '--abbrev=0'],
-                            repodir)[1]
+                            repodir)[1].strip()
             versionformat = re.sub('@PARENT_TAG@', text, versionformat)
         except SystemExit:
             sys.exit(r'\e[0;31mThe git repository has no tags,'

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -66,8 +66,9 @@ class GitTests(GitHgTests):
     # N.B. --versionformat gets tested thoroughly in githgtests.py
 
     def test_versionformat_parenttag(self):
-        self.tar_scm_std('--versionformat', "@PARENT_TAG@")
-        self.assertTarOnly(self.basename(version=self.rev(2)))
+        # the .1 to catch newlines at the end of PARENT_TAG
+        self.tar_scm_std('--versionformat', "@PARENT_TAG@.1")
+        self.assertTarOnly(self.basename(version=self.rev(2)) + '.1')
 
     def _submodule_fixture(self, submod_name):
         fix = self.fixtures


### PR DESCRIPTION
@PARENT_TAG@ had a trailing newline with git as SCM, leading to invalid version strings.