### PR TITLE
Strip newlines from git describe output used for @PARENT_TAG@.

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -368,7 +368,7 @@ def detect_version_git(repodir, versionformat):
     if re.match('.*@PARENT_TAG@.*', versionformat):
         try:
             text = safe_run(['git', 'describe', '--tags', '--abbrev=0'],
-                            repodir)[1]
+                            repodir)[1].strip()
             versionformat = re.sub('@PARENT_TAG@', text, versionformat)
         except SystemExit:
             sys.exit(r'\e[0;31mThe git repository has no tags,'


### PR DESCRIPTION
Not a python guy and did not run this, feel free to tell me what to change it to. I may try and figure out how to run this locally. The result I get for `<param name="versionformat">@PARENT_TAG@+git%cd.%h</param>` include a `\n` which does not seem intended.

The file name that is created:

```
obs-studio-0.6.4
+git20141109.ab7fa5b
```

which seems a bit scary.
