### PR TITLE
Fix Mercurial version format strings in unittest

### DIFF
--- a/tests/hgtests.py
+++ b/tests/hgtests.py
@@ -22,8 +22,8 @@ class HgTests(GitHgTests):
 
     abbrev_hash_format = '{node|short}'
     timestamp_format   = '{date}'
-    yyyymmdd_format    = '{date|shortdate}'
-    yyyymmddhhmmss_format = '{date|isodatesec}'
+    yyyymmdd_format    = '{date|localdate|shortdate}'
+    yyyymmddhhmmss_format = '{date|localdate|isodatesec}'
 
     def default_version(self):
         return self.rev(2)


### PR DESCRIPTION
In hgtests.py we let hg create the timestamp in UTC but create the
reference timestamp in the local timezone. Since GIT is giving us the
localtime in the test by default lets do the same thing for Mercurial.

Signed-off-by: Jan Blunck jblunck@infradead.org
