### PR TITLE
Use commit timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bzr git mercurial subversion
-install: pip install pep8 lxml mock
+install: pip install pep8 lxml mock python-dateutil
 script: make check

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-tar-scm
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 8.0.0), bzr, git, mercurial, pep8, python (>= 2.6), python-argparse | python (>= 2.7), python-unittest2, subversion
+Build-Depends: debhelper (>= 8.0.0), bzr, git, mercurial, pep8, python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil, python-unittest2, subversion
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-tar_scm
 X-Python-Version: >= 2.6

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import dateutil.parser
 from urlparse import urlparse
 
 DEFAULT_AUTHOR = 'opensuse-packaging@opensuse.org'
@@ -314,7 +315,7 @@ METADATA_PATTERN = re.compile(r'.*/\.(bzr|git|hg|svn).*')
 
 
 def create_tar(repodir, outdir, dstname, extension='tar',
-               exclude=[], include=[], package_metadata=False):
+               exclude=[], include=[], package_metadata=False, timestamp=0):
     """Create a tarball of repodir in destination directory."""
     (workdir, topdir) = os.path.split(repodir)
 
@@ -353,6 +354,7 @@ def create_tar(repodir, outdir, dstname, extension='tar',
         """Python 2.7 only: reset uid/gid to 0/0 (root)."""
         tarinfo.uid = tarinfo.gid = 0
         tarinfo.uname = tarinfo.gname = "root"
+        tarinfo.mtime = timestamp
         return tarinfo
 
     def tar_filter(tarinfo):
@@ -523,6 +525,51 @@ def detect_version(scm, repodir, versionformat=None):
     version = detect_version_commands[scm](repodir, versionformat).strip()
     logging.debug("VERSION(auto): %s", version)
     return version
+
+
+def get_timestamp_bzr(repodir):
+    log = safe_run(['bzr', 'log', '--limit=1', '--log-format=long'],
+                   repodir)[1]
+    match = re.search(r'timestamp:(.*)', log, re.MULTILINE)
+    if not match:
+        return 0
+    timestamp = dateutil.parser.parse(match.group(1).strip()).strftime("%s")
+    return int(timestamp)
+
+
+def get_timestamp_hg(repodir):
+    timestamp = detect_version_hg(repodir, versionformat="{date}")
+    timestamp = re.sub(r'([0-9]+)\..*', r'\1', timestamp)
+    return int(timestamp)
+
+
+def get_timestamp_svn(repodir):
+    svn_info = safe_run(['svn', 'info', '-rHEAD'], repodir)[1]
+
+    match = re.search('Last Changed Date: (.*)', svn_info, re.MULTILINE)
+    if not match:
+        return 0
+
+    timestamp = match.group(1).strip()
+    timestamp = re.sub('\(.*\)', '', timestamp)
+    timestamp = dateutil.parser.parse(timestamp).strftime("%s")
+    return int(timestamp)
+
+
+def get_timestamp(args, clone_dir):
+    """Returns the commit timestamp for checked-out repository."""
+    get_timestamp_commands = {
+        'git': lambda x: int(detect_version_git(x, versionformat="%ct")),
+        'svn': get_timestamp_svn,
+        'hg':  get_timestamp_hg,
+        'bzr': get_timestamp_bzr
+    }
+
+    timestamp = get_timestamp_commands[args.scm](clone_dir)
+    logging.debug("COMMIT TIMESTAMP: %s (%s)", timestamp,
+                  datetime.datetime.fromtimestamp(timestamp).strftime(
+                      '%Y-%m-%d %H:%M:%S'))
+    return timestamp
 
 
 def get_repocache_hash(scm, url, subdir):
@@ -1008,7 +1055,8 @@ def main():
     create_tar(tar_dir, args.outdir,
                dstname=dstname, extension=args.extension,
                exclude=args.exclude, include=args.include,
-               package_metadata=args.package_meta)
+               package_metadata=args.package_meta,
+               timestamp=get_timestamp(args, clone_dir))
 
     if changes:
         changesauthor = get_changesauthor(args)

--- a/tests/bzrfixtures.py
+++ b/tests/bzrfixtures.py
@@ -30,3 +30,8 @@ class BzrFixtures(Fixtures):
     def record_rev(self, wd, rev_num):
         self.revs[rev_num] = str(rev_num)
         self.scmlogs.annotate("Recorded rev %d" % rev_num)
+
+    def get_committer_date(self):
+        '''There seems to be no way to create a commit with a given timestamp
+        set for Bazar.'''
+        return ''

--- a/tests/bzrtests.py
+++ b/tests/bzrtests.py
@@ -36,3 +36,8 @@ class BzrTests(CommonTests):
         basename = self.basename(version='foo2')
         th = self.assertTarOnly(basename)
         self.assertTarMemberContains(th, basename + '/a', '2')
+
+    def assertDirentsMtime(self, entries):
+        '''Skip this test with bazaar because there seem to be no way to create
+        commits with a given timestamp.'''
+        return True

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,6 +17,9 @@ class Fixtures:
     subdir2 = 'subdir2'
     _next_commit_revs = {}
 
+    # the timestamp (in seconds since epoch ) that should be used for commits
+    COMMITTER_DATE = int(1234567890)
+
     def __init__(self, container_dir, scmlogs):
         self.container_dir = container_dir
         self.scmlogs       = scmlogs
@@ -79,7 +82,11 @@ class Fixtures:
 
     def do_commit(self, wd, new_rev, newly_created):
         self.safe_run('add .')
-        self.safe_run('commit -m%d' % new_rev)
+        date = self.get_committer_date()
+        self.safe_run('commit -m%d %s' % (new_rev, date))
+
+    def get_committer_date(self):
+        return '--date="%s"' % str(self.COMMITTER_DATE)
 
     def prep_commit(self, new_rev, subdir=None):
         """

--- a/tests/gitfixtures.py
+++ b/tests/gitfixtures.py
@@ -26,6 +26,9 @@ class GitFixtures(Fixtures):
         self.timestamps = {}
         self.sha1s      = {}
 
+        # Force the committer timestamp to our well known default
+        os.environ["GIT_COMMITTER_DATE"] = self.get_committer_date()
+
         self.create_commits(2)
 
     def run(self, cmd):

--- a/tests/hgfixtures.py
+++ b/tests/hgfixtures.py
@@ -53,3 +53,6 @@ class HgFixtures(Fixtures):
              self.timestamps[tag],
              self.sha1s[tag])
         )
+
+    def get_committer_date(self):
+        return '--date="%s"' % (str(self.COMMITTER_DATE) + " 0")

--- a/tests/svnfixtures.py
+++ b/tests/svnfixtures.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python2
 
 import os
+import stat
 
 from fixtures import Fixtures
 from utils    import mkfreshdir, quietrun, run_svn
+from datetime import datetime
 
 
 class SvnFixtures(Fixtures):
@@ -12,6 +14,9 @@ class SvnFixtures(Fixtures):
 
     svn tests use this class in order to have something to test against.
     """
+
+    SVN_COMMITTER_DATE = datetime.utcfromtimestamp(
+        Fixtures.COMMITTER_DATE).isoformat() + ".000000Z"
 
     def init(self):
         self.wd_path = self.container_dir + '/wd'
@@ -28,6 +33,13 @@ class SvnFixtures(Fixtures):
 
     def create_repo(self):
         quietrun('svnadmin create ' + self.repo_path)
+        # allow revprop changes to explicitly set svn:date
+        hook = self.repo_path + '/hooks/pre-revprop-change'
+        f = open(hook, 'w')
+        f.write("#!/bin/sh\nexit 0;\n")
+        f.close()
+        st = os.stat(hook)
+        os.chmod(hook, st.st_mode | stat.S_IEXEC)
         print "created repo", self.repo_path
 
     def checkout_repo(self):
@@ -41,6 +53,8 @@ class SvnFixtures(Fixtures):
                 self.safe_run('add ' + new)
                 self.added[new] = True
         self.safe_run('commit -m%d' % new_rev)
+        self.safe_run('propset svn:date --revprop -r HEAD %s' %
+                      self.SVN_COMMITTER_DATE)
         return new_rev
 
     def get_metadata(self, formatstr):

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -3,6 +3,7 @@
 import os
 from pprint import pprint, pformat
 import re
+import sys
 import tarfile
 import unittest
 
@@ -65,16 +66,29 @@ class TestAssertions(unittest.TestCase):
         self.assertEqual(expected, got, msg)
         return th, tarents
 
+    def assertDirentsMtime(self, entries):
+        '''This test is disabled on Python 2.6 because tarfile is not able to
+        directly change the mtime for an entry in the tarball.'''
+        if sys.hexversion < 0x02070000:
+            return
+        for i in range(0, len(entries)):
+            self.assertEqual(entries[i].mtime, 1234567890)
+
+    def assertDirents(self, entries, top):
+        self.assertEqual(entries[0].name, top)
+        self.assertEqual(entries[1].name, top + '/a')
+        self.assertEqual(entries[2].name, top + '/c')
+        self.assertDirentsMtime(entries)
+
     def assertSubdirDirents(self, entries, top):
         self.assertEqual(entries[0].name, top)
         self.assertEqual(entries[1].name, top + '/b')
+        self.assertDirentsMtime(entries)
 
     def assertStandardTar(self, tar, top):
         th, entries = self.assertNumTarEnts(tar, 5)
         entries.sort(lambda x, y: cmp(x.name, y.name))
-        self.assertEqual(entries[0].name, top)
-        self.assertEqual(entries[1].name, top + '/a')
-        self.assertEqual(entries[2].name, top + '/c')
+        self.assertDirents(entries[:3], top)
         self.assertSubdirDirents(entries[3:], top + '/subdir')
         return th
 


### PR DESCRIPTION
This branch depends on fix_hgtest branch. Additionally to that I'm going to refactor the additional unittest after merging the fix_include_exclude branch.

For an enterprise setup it is important that the generated tarballs are binary identical if they are generated from the same source revision. This commit makes tar_scm use the commit timestamp as a reference for the mtime of the files included in the tarball. The unittest is using a fixed, well known value instead to check that the mtime is taken from the source repository.