### PR TITLE
fix Makefile test runner for Debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tar_scm
 *.pyc
 .*.sw?
 tmp/

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,9 @@ Run the unit test suite via:
     export PYTHONPATH=.    # or absolute path to repo
     python2 tests/test.py
 
+(If your distribution does not have `python2` in your `$PATH` then
+adjust the executable name accordingly.)
+
 The output may become easier to understand if you uncomment the
 'failfast' option in `test.py`.  This requires Python 2.7, however.
 You may also find that the buffered `STDOUT` from test failures gets

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # A simple script to checkout or update a svn or git repo as source service
 #


### PR DESCRIPTION
On Debian, python2 isn't in the `$PATH`, so falling back to `python` should at least get the tests running OK, even if the `#!/usr/bin/env python2` will still break:

  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634967