### PR TITLE
Add sslverify parameter.

### DIFF
--- a/tar_scm.service
+++ b/tar_scm.service
@@ -100,6 +100,11 @@
     <allowedvalue>enable</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+  <parameter name="sslverify">
+    <description>Specify Whether or not to check server certificate against installed CAs.  Default is 'enable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
   <parameter name="changesgenerate">
     <description>Specify whether to generate changes file entries from SCM commit log since a given parent revision (see changesrevision).  Default is 'disable'.</description>
     <allowedvalue>enable</allowedvalue>

--- a/tests/bzrtests.py
+++ b/tests/bzrtests.py
@@ -16,6 +16,7 @@ class BzrTests(CommonTests):
     scm = 'bzr'
     initial_clone_command = 'bzr checkout'
     update_cache_command  = 'bzr update'
+    sslverify_false_args  = '-Ossl.cert_reqs=None'
     fixtures_class = BzrFixtures
 
     def default_version(self):

--- a/tests/commontests.py
+++ b/tests/commontests.py
@@ -262,3 +262,16 @@ class CommonTests(TestEnvironment, TestAssertions):
             ],
             use_cache
         )
+
+    def test_sslverify_disabled(self):
+        self.tar_scm_std('--sslverify', 'disable')
+        logpath = self.scmlogs.current_log_path
+        loglines = self.scmlogs.read()
+        self.assertRanInitialClone(logpath, loglines)
+        self.assertSSLVerifyFalse(logpath, loglines)
+
+    def test_sslverify_enabled(self):
+        self.tar_scm_std('--sslverify', 'enable')
+        logpath = self.scmlogs.current_log_path
+        loglines = self.scmlogs.read()
+        self.assertRanInitialClone(logpath, loglines)

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -22,6 +22,7 @@ class GitTests(GitHgTests):
     scm = 'git'
     initial_clone_command = 'git clone'
     update_cache_command  = 'git fetch'
+    sslverify_false_args  = '--config http.sslverify=false'
     fixtures_class = GitFixtures
 
     abbrev_hash_format = '%h'

--- a/tests/hgtests.py
+++ b/tests/hgtests.py
@@ -18,6 +18,7 @@ class HgTests(GitHgTests):
     scm = 'hg'
     initial_clone_command = 'hg clone'
     update_cache_command  = 'hg pull'
+    sslverify_false_args  = '--insecure'
     fixtures_class = HgFixtures
 
     abbrev_hash_format = '{node|short}'

--- a/tests/svntests.py
+++ b/tests/svntests.py
@@ -16,6 +16,7 @@ class SvnTests(CommonTests):
     scm = 'svn'
     initial_clone_command = 'svn (co|checkout) '
     update_cache_command  = 'svn up(date)?'
+    sslverify_false_args  = '--trust-server-cert'
     fixtures_class = SvnFixtures
 
     def default_version(self):

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -135,6 +135,12 @@ class TestAssertions(unittest.TestCase):
         self._find(logpath, loglines,
                    self.initial_clone_command, self.update_cache_command)
 
+    def assertSSLVerifyFalse(self, logpath, loglines):
+        self._find(logpath, loglines,
+                   self.initial_clone_command +
+                   '.*' + self.sslverify_false_args,
+                   self.sslverify_false_args + 'true')
+
     def assertRanUpdate(self, logpath, loglines):
         self._find(logpath, loglines,
                    self.update_cache_command, self.initial_clone_command)


### PR DESCRIPTION
In order to checkout sources from self-signed hosts add a parameter
for disabling certificate checks in scm tools.