### PR TITLE
Allow to manually specify a base for @TAG_OFFSET@

### DIFF
--- a/tar_scm.service
+++ b/tar_scm.service
@@ -54,6 +54,12 @@
   <parameter name="versionprefix">
     <description>Specify a base version as prefix.</description>
   </parameter>
+  <parameter name="parent-tag">
+    <description>
+      This parameter allows overriding the tag that is being used for
+      computing @TAG_OFFSET@.
+    </description>
+  </parameter>
   <parameter name="revision">
     <description>
        Specify revision of source to check out.

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -66,6 +66,15 @@ class GitTests(GitHgTests):
 
     # N.B. --versionformat gets tested thoroughly in githgtests.py
 
+    def test_parent_tag(self):
+        f = self.fixtures
+        f.create_commits(1)
+        base = f.get_metadata("%H")
+        f.create_commits(3)
+        self.tar_scm_std("--parent-tag", base,
+                         "--versionformat", "@TAG_OFFSET@")
+        self.assertTarOnly(self.basename(version="3"))
+
     def test_versionformat_parenttag(self):
         # the .1 to catch newlines at the end of PARENT_TAG
         self.tar_scm_std('--versionformat', "@PARENT_TAG@.1")


### PR DESCRIPTION
This permits to use, in the _service file,

	<param name="parent-tag">(hash of root commit)</param>
	<param name="versionformat">1.2.3.@TAG_OFFSET@.%h</param>

and get a monotonically increasing number (for the particular
branch it draws from).