### PR TITLE
obscpio implementation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,6 +56,7 @@ install: tar_scm
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/obs_scm
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/tar
 	install -m 0644 tar.service $(DESTDIR)$(mylibdir)/tar.service
+	install -m 0644 snapcraft.service $(DESTDIR)$(mylibdir)/snapcraft.service
 	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/tar_scm.service
 	sed -e '/^===TAR_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/obs_scm.service
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,8 +52,12 @@ install: tar_scm
 	mkdir -p $(DESTDIR)$(mylibdir)
 	mkdir -p $(DESTDIR)$(mycfgdir)
 	install -m 0755 tar_scm $(DESTDIR)$(mylibdir)/tar_scm
-	install -m 0644 tar_scm.service $(DESTDIR)$(mylibdir)
 	install -m 0644 tar_scm.rc $(DESTDIR)$(mycfgdir)/tar_scm
+	ln -s tar_scm $(DESTDIR)$(mylibdir)/obs_scm
+	ln -s tar_scm $(DESTDIR)$(mylibdir)/tar
+	install -m 0644 tar.service $(DESTDIR)$(mylibdir)/tar.service
+	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/tar_scm.service
+	sed -e '/^===TAR_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/obs_scm.service
 
 show-python:
 	@echo "$(PYTHON)"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -55,6 +55,7 @@ install: tar_scm
 	install -m 0644 tar_scm.rc $(DESTDIR)$(mycfgdir)/tar_scm
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/obs_scm
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/tar
+	ln -s tar_scm $(DESTDIR)$(mylibdir)/snapcraft
 	install -m 0644 tar.service $(DESTDIR)$(mylibdir)/tar.service
 	install -m 0644 snapcraft.service $(DESTDIR)$(mylibdir)/snapcraft.service
 	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/tar_scm.service

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ X-Python-Version: >= 2.6
 
 Package: obs-service-tar-scm
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, mercurial, subversion
+Provides: obs-service-obs-scm, obs-service-tar
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, mercurial, subversion, cpio
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.

--- a/obs_scm
+++ b/obs_scm
@@ -1,0 +1,1 @@
+tar_scm.py

--- a/snapcraft
+++ b/snapcraft
@@ -1,0 +1,1 @@
+tar_scm.py

--- a/snapcraft.service
+++ b/snapcraft.service
@@ -1,0 +1,4 @@
+<service name="snapcraft">
+<summary>handle sources specified in snapcraft.yaml</summary>
+   <description>This service needs to be executed to download sources according to snapcraft.yaml file. It also patches the snapcraft tile to use local sources during build.</description>
+</service>

--- a/tar
+++ b/tar
@@ -1,0 +1,1 @@
+tar_scm.py

--- a/tar.service
+++ b/tar.service
@@ -3,7 +3,6 @@
   <description>This service is packaging a directory structure into a tar ball. The directory gets created via the obs_scm service usually. This service reads the .obsinfo file to learn how to create the tar ball.</description>
   <parameter name="obsinfo">
     <description>Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter.</description>
-    <required/>
   </parameter>
   <parameter name="version">
     <description>Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter.</description>

--- a/tar.service
+++ b/tar.service
@@ -1,0 +1,20 @@
+<service name="tar">
+  <summary>Create a tarball from SCM repository</summary>
+  <description>This service is packaging a directory structure into a tar ball. The directory gets created via the obs_scm service usually. This service reads the .obsinfo file to learn how to create the tar ball.</description>
+  <parameter name="obsinfo">
+    <description>Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter.</description>
+    <required/>
+  </parameter>
+  <parameter name="version">
+    <description>Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter.</description>
+  </parameter>
+  <parameter name="versionprefix">
+    <description>Specify a base version as prefix.</description>
+  </parameter>
+  <parameter name="filename">
+    <description>Specify name of package, which is used together with version to determine tarball name.</description>
+  </parameter>
+  <parameter name="extension">
+    <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
+  </parameter>
+</service>

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -356,7 +356,6 @@ def create_cpio(repodir, basename, dstname, version, commit, args):
     """
     (workdir, topdir) = os.path.split(repodir)
     extension = 'obscpio'
-    excludes = args.exclude
 
     cwd = os.getcwd()
     os.chdir(workdir)
@@ -370,7 +369,7 @@ def create_cpio(repodir, basename, dstname, version, commit, args):
 
     # transform glob patterns to regular expressions
     includes = r'|'.join([fnmatch.translate(x) for x in args.include])
-    excludes = r'|'.join([fnmatch.translate(x) for x in excludes]) or r'$.'
+    excludes = r'|'.join([fnmatch.translate(x) for x in args.exclude]) or r'$.'
 
     # add topdir without filtering for now
     for root, dirs, files in os.walk(topdir, topdown=False):
@@ -395,7 +394,7 @@ def create_cpio(repodir, basename, dstname, version, commit, args):
     ret_code = proc.wait()
     if ret_code != 0:
         sys.exit("creating the cpio archive failed!")
-    archivefile.flush()
+    archivefile.close()
 
     # write meta data
     metafile = open(os.path.join(args.outdir, basename + '.obsinfo'), "w")
@@ -404,7 +403,7 @@ def create_cpio(repodir, basename, dstname, version, commit, args):
     # metafile.write("git describe: " + + "\n")
     if commit:
         metafile.write("commit: " + commit + "\n")
-    metafile.flush()
+    metafile.close()
 
     os.chdir(cwd)
 

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -232,7 +232,7 @@ def switch_revision_git(clone_dir, revision):
             print text.rstrip()
             break
 
-    if found_revision == None:
+    if found_revision is None:
         sys.exit('%s: No such revision' % revision)
 
     # only update submodules if they have been enabled
@@ -286,7 +286,7 @@ def _calc_dir_to_clone_to(scm, url, prefix, out_dir):
 def fetch_upstream(scm, url, revision, out_dir, **kwargs):
     """Fetch sources from repository and checkout given revision."""
     clone_prefix = ""
-    if kwargs.has_key('clone_prefix'):
+    if 'clone_prefix' in kwargs:
         clone_prefix = kwargs['clone_prefix']
     clone_dir = _calc_dir_to_clone_to(scm, url, clone_prefix, out_dir)
 
@@ -648,6 +648,7 @@ def detect_version(args, repodir):
 def get_timestamp_tar(repodir):
     return int(0)
 
+
 def get_timestamp_bzr(repodir):
     log = safe_run(['bzr', 'log', '--limit=1', '--log-format=long'],
                    repodir)[1]
@@ -659,13 +660,13 @@ def get_timestamp_bzr(repodir):
 
 
 def get_timestamp_git(repodir):
-    d = {"parent_tag" : None, "versionformat" : "%ct"}
+    d = {"parent_tag": None, "versionformat": "%ct"}
     timestamp = detect_version_git(d, repodir)
     return int(timestamp)
 
 
 def get_timestamp_hg(repodir):
-    d = {"parent_tag" : None, "versionformat" : "{date}"}
+    d = {"parent_tag": None, "versionformat": "{date}"}
     timestamp = detect_version_hg(d, repodir)
     timestamp = re.sub(r'([0-9]+)\..*', r'\1', timestamp)
     return int(timestamp)
@@ -1211,24 +1212,27 @@ def main():
         f.close()
         # run for each part an own task
         for part in dataMap['parts'].keys():
-           args.filename = part
-           if not 'source-type' in dataMap['parts'][part].keys():
-              continue
-           if not dataMap['parts'][part]['source-type'] in FETCH_UPSTREAM_COMMANDS.keys():
-              continue
-           # avoid conflicts with files
-           args.clone_prefix = "_obs_"
-           args.url = dataMap['parts'][part]['source']
-           dataMap['parts'][part]['source'] = part
-           args.scm = dataMap['parts'][part]['source-type']
-           del dataMap['parts'][part]['source-type']
-           singletask(True, args)
+            args.filename = part
+            if 'source-type' not in dataMap['parts'][part].keys():
+                continue
+            pep8_1 = dataMap['parts'][part]['source-type']
+            pep8_2 = FETCH_UPSTREAM_COMMANDS.keys()
+            if pep8_1 not in pep8_2:
+                continue
+            # avoid conflicts with files
+            args.clone_prefix = "_obs_"
+            args.url = dataMap['parts'][part]['source']
+            dataMap['parts'][part]['source'] = part
+            args.scm = dataMap['parts'][part]['source-type']
+            del dataMap['parts'][part]['source-type']
+            singletask(True, args)
 
         # write the new snapcraft.yaml file
         # we prefix our own here to be sure to not overwrite user files, if he
         # is using us in "disabled" mode
-        with open(args.outdir+'/_service:snapcraft:snapcraft.yaml', 'w') as outfile:
-           outfile.write( yaml.dump(dataMap, default_flow_style=False) )
+        new_file = args.outdir + '/_service:snapcraft:snapcraft.yaml'
+        with open(new_file, 'w') as outfile:
+            outfile.write(yaml.dump(dataMap, default_flow_style=False))
     else:
         singletask(use_obs_scm, args)
 
@@ -1263,7 +1267,8 @@ def singletask(use_obs_scm, args):
     # special case when using osc and creating an obscpio, use current work
     # directory to allow the developer to work inside of the git repo and fetch
     # local changes
-    if sys.argv[0].endswith("snapcraft") or (use_obs_scm and os.getenv('OSC_VERSION')):
+    if sys.argv[0].endswith("snapcraft") or \
+       (use_obs_scm and os.getenv('OSC_VERSION')):
         repodir = os.getcwd()
 
     if args.scm == "tar":
@@ -1289,7 +1294,8 @@ def singletask(use_obs_scm, args):
 
     version = get_version(args, clone_dir)
     changesversion = version
-    if version and not sys.argv[0].endswith("/tar") and not sys.argv[0].endswith("/snapcraft"):
+    if version and not sys.argv[0].endswith("/tar") \
+       and not sys.argv[0].endswith("/snapcraft"):
         dstname += '-' + version
 
     logging.debug("DST: %s", dstname)

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1223,7 +1223,7 @@ def main():
         # write the new snapcraft.yaml file
         # we prefix our own here to be sure to not overwrite user files, if he
         # is using us in "disabled" mode
-        with open(args.outdir+'/_service:snapcraft:snapcraft.yml', 'w') as outfile:
+        with open(args.outdir+'/_service:snapcraft:snapcraft.yaml', 'w') as outfile:
            outfile.write( yaml.dump(dataMap, default_flow_style=False) )
     else:
         singletask(use_obs_scm, args)

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -472,7 +472,7 @@ CLEANUP_DIRS = []
 
 def cleanup(dirs):
     """Cleaning temporary directories."""
-    logging.info("Cleaning: %s", ' '.join(dirs))
+    logging.debug("Cleaning: %s", ' '.join(dirs))
 
     for d in dirs:
         if not os.path.exists(d):

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1084,6 +1084,13 @@ def main():
         repodir = os.getcwd()
 
     if args.scm == "tar":
+        if args.obsinfo == None:
+            files = glob.glob('*.obsinfo')
+            if len(files) > 0:
+                # or we refactor and loop about all on future
+                args.obsinfo = files[0]
+        if args.obsinfo == None:
+            sys.exit("ERROR: no .obsinfo file found")
         basename = clone_dir = read_from_obsinfo(args.obsinfo, "name")
         clone_dir += "-" + read_from_obsinfo(args.obsinfo, "version")
         if not os.path.exists(clone_dir):

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -28,8 +28,14 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import yaml
 import dateutil.parser
+
+try:
+    # not possible to test this on travis atm
+    import yaml
+except ImportError:
+    pass
+
 from urlparse import urlparse
 
 DEFAULT_AUTHOR = 'opensuse-packaging@opensuse.org'

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -212,9 +212,11 @@ def switch_revision_git(clone_dir, revision):
     if revision is None:
         revision = 'master'
 
+    found_revision = None
     revs = [x + revision for x in ['origin/', '']]
     for rev in revs:
         if git_ref_exists(clone_dir, rev):
+            found_revision = True
             if os.getenv('OSC_VERSION'):
                 stash_text = safe_run(['git', 'stash'], cwd=clone_dir)[1]
                 text = safe_run(['git', 'reset', '--hard', rev],
@@ -227,7 +229,8 @@ def switch_revision_git(clone_dir, revision):
                                 cwd=clone_dir)[1]
             print text.rstrip()
             break
-    else:
+
+    if found_revision == None:
         sys.exit('%s: No such revision' % revision)
 
     # only update submodules if they have been enabled

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -522,7 +522,7 @@ def read_from_obsinfo(filename, key):
 
 def detect_version_tar(args, repodir):
     """Read former stored version."""
-    return read_from_obsinfo(args.obsinfo, "version")
+    return read_from_obsinfo(args['obsinfo'], "version")
 
 
 def detect_version_git(args, repodir):
@@ -637,13 +637,16 @@ def detect_version(args, repodir):
         'svn': detect_version_svn,
         'hg':  detect_version_hg,
         'bzr': detect_version_bzr,
-        'tar': detect_version_tar,
+        'tar': detect_version_tar
     }
 
     version = detect_version_commands[args.scm](args.__dict__, repodir).strip()
     logging.debug("VERSION(auto): %s", version)
     return version
 
+
+def get_timestamp_tar(repodir):
+    return int(0)
 
 def get_timestamp_bzr(repodir):
     log = safe_run(['bzr', 'log', '--limit=1', '--log-format=long'],
@@ -687,7 +690,8 @@ def get_timestamp(args, clone_dir):
         'git': get_timestamp_git,
         'svn': get_timestamp_svn,
         'hg':  get_timestamp_hg,
-        'bzr': get_timestamp_bzr
+        'bzr': get_timestamp_bzr,
+        'tar': get_timestamp_tar
     }
 
     timestamp = get_timestamp_commands[args.scm](clone_dir)

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -98,6 +98,10 @@
   <parameter name="include">
     <description>Specify subset of files/subdirectories to pack in the tarball.</description>
   </parameter>
+  <parameter name="extract">
+    <description>Specify a file to be exported directly. Useful for build descriptions like spec files
+which get maintained in the SCM. Can be used multiple times.</description>
+  </parameter>
   <parameter name="package-meta">
     <description>Package the metadata of SCM to allow the user or OBS to update after un-tar.</description>
     <allowedvalue>yes</allowedvalue>

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -1,6 +1,16 @@
+===OBS_ONLY
+<service name="obs_scm">
+<summary>Create a special OBS archive from a SCM</summary>
+   <description>This service uses a SCM client to checkout or update from a given repository. Supported are svn, git, hg and bzr. The result will archived in a format which can be stored
+   incremental by the OBS source server, currently a cpio format. This archive will be extracted again inside of the build root.</description>
+===
+
+===TAR_ONLY
 <service name="tar_scm">
   <summary>Create a tarball from SCM repository</summary>
   <description>This service uses a SCM client to checkout or update from a given repository.  Supported are svn, git, hg and bzr.</description>
+===
+
   <parameter name="scm">
     <description>Specify SCM to use.</description>
     <allowedvalue>svn</allowedvalue>

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -24,7 +24,7 @@ class UnitTestCases(unittest.TestCase):
         ]
 
         for cd in clone_dirs:
-            clone_dir = _calc_dir_to_clone_to(scm, cd, outdir)
+            clone_dir = _calc_dir_to_clone_to(scm, cd, None, outdir)
             self.assertEqual(clone_dir, os.path.join(outdir, 'repo'))
 
     @patch('tar_scm.safe_run')

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -24,7 +24,7 @@ class UnitTestCases(unittest.TestCase):
         ]
 
         for cd in clone_dirs:
-            clone_dir = _calc_dir_to_clone_to(scm, cd, None, outdir)
+            clone_dir = _calc_dir_to_clone_to(scm, cd, "", outdir)
             self.assertEqual(clone_dir, os.path.join(outdir, 'repo'))
 
     @patch('tar_scm.safe_run')


### PR DESCRIPTION
New obscpio implementation. We could maintain this also seperate as fork, but I think it makes more sense to merge.

The service package will provide three services in future instead of just tar_scm. The idea behind is to share the code as much as possible, but to describe and limit each service for it's use case.

tar_scm: should behave like before
obs_scm: similar to tar_scm, but will store cpio archive with .obscpio suffix and a .obsinfo file providing additional meta information like the git commit id.
tar: Just for creating a tar ball from a local directory (unpack .obscpio archive)

a working example (when using local build only atm) is in home:adrianSuSE build. The _service file looks like this. Note that the first service is running on the server, while the rest only running inside of the build environment.

```
osc cat home:adrianSuSE build _service

<services>
  <service name="obs_scm">
    <param name="versionformat">%ad</param>
    <param name="url">git://github.com/openSUSE/obs-build.git</param>
    <param name="scm">git</param>
  </service>
  <service name="tar" mode="buildtime">
    <param name="obsinfo">obs-build.obsinfo</param>
  </service>
  <service name="recompress" mode="buildtime">
    <param name="compression">gz</param>
    <param name="file">*.tar</param>
  </service>
  <service name="set_version" mode="buildtime"/>
</services>
```