### PR TITLE
Honour "subdir" param for changesgenerate

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -696,33 +696,41 @@ def write_changes(changes_filename, changes, version, author):
     shutil.move(tmp_fp.name, changes_filename)
 
 
-def detect_changes_commands_git(repodir, changes):
+def detect_changes_commands_git(repodir, subdir, changes):
     """Detect changes between GIT revisions."""
     last_rev = changes['revision']
 
     if last_rev is None:
-        last_rev = safe_run(['git', 'log', '-n1', '--pretty=format:%H',
-                             '--skip=10'], cwd=repodir)[1]
-    current_rev = safe_run(['git', 'log', '-n1', '--pretty=format:%H'],
-                           cwd=repodir)[1]
+        last_cmd = ['git', 'log', '-n1', '--pretty=format:%H', '--skip=10']
+        if subdir:
+            last_cmd += ['--', subdir]
+        last_rev = safe_run(last_cmd, cwd=repodir)[1]
+    current_cmd = ['git', 'log', '-n1', '--pretty=format:%H']
+    if subdir:
+        current_cmd += ['--', subdir]
+    current_rev = safe_run(current_cmd, cwd=repodir)[1]
 
     if last_rev == current_rev:
         logging.debug("No new commits, skipping changes file generation")
         return
 
-    logging.debug("Generating changes between %s and %s", last_rev,
-                  current_rev)
+    dbg_msg = "Generating changes between %s and %s" % (last_rev, current_rev)
+    if subdir:
+        dbg_msg += " (for subdir: %s)" % (subdir)
+    logging.debug(dbg_msg)
 
-    lines = safe_run(['git', 'log',
-                      '--reverse', '--no-merges', '--pretty=format:%s',
-                      "%s..%s" % (last_rev, current_rev)], repodir)[1]
+    cmd = ['git', 'log', '--reverse', '--no-merges', '--pretty=format:%s',
+           "%s..%s" % (last_rev, current_rev)]
+    if subdir:
+        cmd += ['--', subdir]
+    lines = safe_run(cmd, repodir)[1]
 
     changes['revision'] = current_rev
     changes['lines'] = lines.split('\n')
     return changes
 
 
-def detect_changes(scm, url, repodir, outdir):
+def detect_changes(scm, url, repodir, outdir, subdir):
     """Detect changes between revisions."""
     changes = read_changes_revision(url, os.getcwd(), outdir)
 
@@ -735,7 +743,7 @@ def detect_changes(scm, url, repodir, outdir):
     if scm not in detect_changes_commands:
         sys.exit("changesgenerate not supported with %s SCM" % scm)
 
-    changes = detect_changes_commands[scm](repodir, changes)
+    changes = detect_changes_commands[scm](repodir, subdir, changes)
     logging.debug("Detected changes:\n%s" % repr(changes))
     return changes
 
@@ -954,7 +962,8 @@ def main():
 
     changes = None
     if args.changesgenerate:
-        changes = detect_changes(args.scm, args.url, clone_dir, args.outdir)
+        changes = detect_changes(args.scm, args.url, clone_dir, args.outdir,
+                                 args.subdir)
 
     tar_dir = prep_tree_for_tar(clone_dir, args.subdir, args.outdir,
                                 dstname=dstname)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,7 +46,7 @@ class Fixtures:
         raise NotImplementedError(
             self.__class__.__name__ + " didn't implement init()")
 
-    def create_commits(self, num_commits, wd=None):
+    def create_commits(self, num_commits, wd=None, subdir=None):
         self.scmlogs.annotate("Creating %d commits ..." % num_commits)
         if num_commits == 0:
             return
@@ -57,7 +57,7 @@ class Fixtures:
         os.chdir(wd)
 
         for i in xrange(0, num_commits):
-            new_rev = self.create_commit(wd)
+            new_rev = self.create_commit(wd, subdir=subdir)
         self.record_rev(wd, new_rev)
 
         self.scmlogs.annotate("Created %d commits; now at %s" %
@@ -71,9 +71,9 @@ class Fixtures:
         self._next_commit_revs[wd] += 1
         return new_rev
 
-    def create_commit(self, wd):
+    def create_commit(self, wd, subdir=None):
         new_rev = self.next_commit_rev(wd)
-        newly_created = self.prep_commit(new_rev)
+        newly_created = self.prep_commit(new_rev, subdir=subdir)
         self.do_commit(wd, new_rev, newly_created)
         return new_rev
 
@@ -81,23 +81,25 @@ class Fixtures:
         self.safe_run('add .')
         self.safe_run('commit -m%d' % new_rev)
 
-    def prep_commit(self, new_rev):
+    def prep_commit(self, new_rev, subdir=None):
         """
         Caller should ensure correct cwd.
         Returns list of newly created files.
         """
+        if not subdir:
+            subdir = self.subdir
         self.scmlogs.annotate("cwd is %s" % os.getcwd())
         newly_created = []
 
         if not os.path.exists('a'):
             newly_created.append('a')
 
-        if not os.path.exists(self.subdir):
-            os.mkdir(self.subdir)
+        if not os.path.exists(subdir):
+            os.mkdir(subdir)
             # This will take care of adding subdir/b too
-            newly_created.append(self.subdir)
+            newly_created.append(subdir)
 
-        for fn in ('a', self.subdir + '/b'):
+        for fn in ('a', subdir + '/b'):
             f = open(fn, 'w')
             f.write(str(new_rev))
             f.close()

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -330,3 +330,32 @@ class GitTests(GitHgTests):
 
     def test_changesgenerate_new_commit_and_changes_file_default_author(self):
         self._test_changesgenerate_new_commit_and_changes_file()
+
+    def test_changesgenerate_new_commit_and_changes_file_with_subdir(self):
+        self._write_servicedata(2)
+        orig_changes = self._write_changes_file()
+        self.fixtures.create_commits(3)
+        self.fixtures.create_commits(3, subdir='another_subdir')
+
+        tar_scm_args = [
+            '--changesgenerate', 'enable',
+            '--versionformat', '0.6.%h',
+            '--subdir', 'another_subdir',
+            '--changesauthor', self.fixtures.user_email,
+        ]
+
+        self.tar_scm_std(*tar_scm_args)
+
+        self._check_servicedata(revision=8, expected_dirents=3)
+
+        expected_author = self.fixtures.user_email
+        expected_changes_regexp = self._new_change_entry_regexp(
+            expected_author,
+            textwrap.dedent("""\
+              - Update to version 0.6.%s:
+                \+ 6
+                \+ 7
+                \+ 8
+              """) % self.abbrev_sha1s('tag8')
+        )
+        self._check_changes(orig_changes, expected_changes_regexp)


### PR DESCRIPTION
When the "subdir" parameter is set and changes are generated,
only use changes which affect the given "subdir".

Fixes #37