### PR TITLE
Strip "v" from Git Versions when using @PARENT_TAG@

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -447,7 +447,7 @@ def detect_version_git(repodir, versionformat):
 
     version = safe_run(['git', 'log', '-n1', '--date=short',
                         "--pretty=format:%s" % versionformat], repodir)[1]
-    return version_iso_cleanup(version)
+    return version_iso_cleanup(version.lstrip("v"))
 
 
 def detect_version_svn(repodir, versionformat):


### PR DESCRIPTION
Strip the preceeding "v" from the version when using @PARENT_TAG@ to set the version on git sources. 

Relates to issue #92 
