### PR TITLE
Honour "subdir" param for changesgenerate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bzr git mercurial subversion
-install: pip install pep8 lxml
+install: pip install pep8 lxml mock
 script: make check

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,7 +46,7 @@ class Fixtures:
         raise NotImplementedError(
             self.__class__.__name__ + " didn't implement init()")
 
-    def create_commits(self, num_commits, wd=None):
+    def create_commits(self, num_commits, wd=None, subdir=None):
         self.scmlogs.annotate("Creating %d commits ..." % num_commits)
         if num_commits == 0:
             return
@@ -57,7 +57,7 @@ class Fixtures:
         os.chdir(wd)
 
         for i in xrange(0, num_commits):
-            new_rev = self.create_commit(wd)
+            new_rev = self.create_commit(wd, subdir=subdir)
         self.record_rev(wd, new_rev)
 
         self.scmlogs.annotate("Created %d commits; now at %s" %
@@ -71,9 +71,9 @@ class Fixtures:
         self._next_commit_revs[wd] += 1
         return new_rev
 
-    def create_commit(self, wd):
+    def create_commit(self, wd, subdir=None):
         new_rev = self.next_commit_rev(wd)
-        newly_created = self.prep_commit(new_rev)
+        newly_created = self.prep_commit(new_rev, subdir=subdir)
         self.do_commit(wd, new_rev, newly_created)
         return new_rev
 
@@ -81,23 +81,25 @@ class Fixtures:
         self.safe_run('add .')
         self.safe_run('commit -m%d' % new_rev)
 
-    def prep_commit(self, new_rev):
+    def prep_commit(self, new_rev, subdir=None):
         """
         Caller should ensure correct cwd.
         Returns list of newly created files.
         """
+        if not subdir:
+            subdir = self.subdir
         self.scmlogs.annotate("cwd is %s" % os.getcwd())
         newly_created = []
 
         if not os.path.exists('a'):
             newly_created.append('a')
 
-        if not os.path.exists(self.subdir):
-            os.mkdir(self.subdir)
+        if not os.path.exists(subdir):
+            os.mkdir(subdir)
             # This will take care of adding subdir/b too
-            newly_created.append(self.subdir)
+            newly_created.append(subdir)
 
-        for fn in ('a', self.subdir + '/b'):
+        for fn in ('a', subdir + '/b'):
             f = open(fn, 'w')
             f.write(str(new_rev))
             f.close()

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -331,3 +331,32 @@ class GitTests(GitHgTests):
 
     def test_changesgenerate_new_commit_and_changes_file_default_author(self):
         self._test_changesgenerate_new_commit_and_changes_file()
+
+    def test_changesgenerate_new_commit_and_changes_file_with_subdir(self):
+        self._write_servicedata(2)
+        orig_changes = self._write_changes_file()
+        self.fixtures.create_commits(3)
+        self.fixtures.create_commits(3, subdir='another_subdir')
+
+        tar_scm_args = [
+            '--changesgenerate', 'enable',
+            '--versionformat', '0.6.%h',
+            '--subdir', 'another_subdir',
+            '--changesauthor', self.fixtures.user_email,
+        ]
+
+        self.tar_scm_std(*tar_scm_args)
+
+        self._check_servicedata(revision=8, expected_dirents=3)
+
+        expected_author = self.fixtures.user_email
+        expected_changes_regexp = self._new_change_entry_regexp(
+            expected_author,
+            textwrap.dedent("""\
+              - Update to version 0.6.%s:
+                \* 6
+                \* 7
+                \* 8
+              """) % self.abbrev_sha1s('tag8')
+        )
+        self._check_changes(orig_changes, expected_changes_regexp)

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -3,8 +3,10 @@
 import unittest
 import sys
 import os
+from mock import patch
 
 from tar_scm import _calc_dir_to_clone_to
+from tar_scm import _git_log_cmd
 
 
 class UnitTestCases(unittest.TestCase):
@@ -24,3 +26,19 @@ class UnitTestCases(unittest.TestCase):
         for cd in clone_dirs:
             clone_dir = _calc_dir_to_clone_to(scm, cd, outdir)
             self.assertEqual(clone_dir, os.path.join(outdir, 'repo'))
+
+    @patch('tar_scm.safe_run')
+    def test__git_log_cmd_with_args(self, safe_run_mock):
+        new_cmd = _git_log_cmd(['-n1'], None, '')
+        safe_run_mock.assert_called_once_with(['git', 'log', '-n1'], cwd=None)
+
+    @patch('tar_scm.safe_run')
+    def test__git_log_cmd_without_args(self, safe_run_mock):
+        new_cmd = _git_log_cmd([], None, '')
+        safe_run_mock.assert_called_once_with(['git', 'log'], cwd=None)
+
+    @patch('tar_scm.safe_run')
+    def test__git_log_cmd_with_subdir(self, safe_run_mock):
+        new_cmd = _git_log_cmd(['-n1'], None, 'subdir')
+        safe_run_mock.assert_called_once_with(['git', 'log', '-n1',
+                                               '--', 'subdir'], cwd=None)


### PR DESCRIPTION
When the "subdir" parameter is set and changes are generated,
only use changes which affect the given "subdir".

Fixes #37