### PR TITLE
Allow to disable archive mode to track plain file(s)

### DIFF
--- a/tar_scm.service
+++ b/tar_scm.service
@@ -80,7 +80,14 @@
     <description>Specify name of package, which is used together with version to determine tarball name.</description>
   </parameter>
   <parameter name="extension">
-    <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
+    <description>
+      Specify suffix name of package, which is used together with filename to determine tarball name.
+
+      When "extension" is set to an empty string, no tarball will be created. Instead the files (respecting
+      the "exclude" and "include" parameters) are directly copied.
+      This is comparable to the "download_files" source service but "tar_scm" can also create a
+      changelog for the given file(s).
+    </description>
   </parameter>
   <parameter name="exclude">
     <description>Specify regexp to exclude when creating the tarball.</description>


### PR DESCRIPTION
Usually tar_scm creates a tarball archive containing the files from a git repo.
Now when "extension" is set to an empty string, no tarball will be created.
Instead the files (respecting the "exclude" and "include" parameters) are
directly copied. This is comparable to the "download_files" source service but
"tar_scm" can also create a changelog for the given file(s).
This is for example useful when you want to track a .spec file in git and
also want to have the changes done in git for the .spec file in your .changes
file.
