### PR TITLE
Download the latest submodule of git.

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -113,9 +113,12 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
 
 def fetch_upstream_git_submodules(clone_dir, kwargs):
     """Recursively initialize git submodules."""
-    if 'submodules' in kwargs and kwargs['submodules']:
+    if 'submodules' in kwargs and kwargs['submodules'] == 'enable':
         safe_run(['git', 'submodule', 'update', '--init', '--recursive'],
                  cwd=clone_dir)
+    elif 'submodules' in kwargs and kwargs['submodules'] == 'master':
+        safe_run(['git', 'submodule', 'update', '--init', '--recursive',
+                 '--remote'], cwd=clone_dir)
 
 
 def fetch_upstream_svn(url, clone_dir, revision, cwd, kwargs):
@@ -1116,11 +1119,13 @@ def parse_args():
                              DEFAULT_AUTHOR)
     parser.add_argument('--subdir', default='',
                         help='Package just a subdirectory of the sources')
-    parser.add_argument('--submodules', choices=['enable', 'disable'],
+    parser.add_argument('--submodules',
+                        choices=['enable', 'master', 'disable'],
                         default='enable',
                         help='Whether or not to include git submodules '
                              'from SCM commit log since a given parent '
-                             'revision (see changesrevision).')
+                             'revision (see changesrevision). Use '
+                             '\'master\' to fetch the latest master.')
     parser.add_argument('--sslverify', choices=['enable', 'disable'],
                         default='enable',
                         help='Whether or not to check server certificate '
@@ -1172,10 +1177,6 @@ def parse_args():
     else:
         args.package_meta = False
 
-    if args.submodules == 'enable':
-        args.submodules = True
-    else:
-        args.submodules = False
     args.sslverify = False if args.sslverify == 'disable' else True
 
     # force verbose mode in test-mode

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -118,6 +118,7 @@ which get maintained in the SCM. Can be used multiple times.</description>
   <parameter name="submodules">
     <description>Specify whether to include git submodules.  Default is 'enable'.</description>
     <allowedvalue>enable</allowedvalue>
+    <allowedvalue>master</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
   <parameter name="sslverify">

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -177,6 +177,23 @@ class GitTests(GitHgTests, GitSvnTests):
                                    submod_name, 'a')
         self.assertTarMemberContains(th, submod_path, '3')
 
+    def test_latest_submodule_in_different_branch(self):
+        submod_name = 'submod1'
+
+        rev = 'build'
+        self._submodule_fixture_prepare_branch(rev)
+        self._submodule_fixture(submod_name)
+
+        self.tar_scm_std('--submodules', 'master',
+                         '--revision', rev,
+                         '--version', rev)
+        tar_path = os.path.join(self.outdir,
+                                self.basename(version=rev) + '.tar')
+        th = tarfile.open(tar_path)
+        submod_path = os.path.join(self.basename(version=rev),
+                                   submod_name, 'a')
+        self.assertTarMemberContains(th, submod_path, '5')
+
     def _check_servicedata(self, expected_dirents=2, revision=2):
         expected_sha1 = self.sha1s('tag%d' % revision)
         dirents = self.assertNumDirents(self.outdir, expected_dirents)


### PR DESCRIPTION
(Fix the test suite compare to the first pull request.)

When the origin git repo doesn't update the submodule,
"git submodule update --init --recursive" couldn't
get the latest commits in master, need the option
"--remote" to get the latest commits of remote
submodules.

If the upstream maintainer forget to update the submodules,
it will never get the latest commits of submodules without
"--remote".
