### PR TITLE
tar_scm.py: Always use an absolute path for the 'output' directory

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1155,6 +1155,7 @@ def parse_args():
     if not os.path.isdir(args.outdir):
         sys.exit("%s: No such directory" % args.outdir)
 
+    args.outdir = os.path.abspath(args.outdir)
     orig_subdir = args.subdir
     args.subdir = os.path.normpath(orig_subdir)
     if args.subdir.startswith('/'):


### PR DESCRIPTION
output directory is expected to be an absolute path but this is not
being enforced in the code. If a relative path is passed, it can lead
to failures since the working directoy changes during the code so
the relative path will no longer be valid.