### PR TITLE
Allow to extract the version based on git describe --tags without shortening

### DIFF
--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -61,6 +61,13 @@
       For bzr and svn, '%r' is expanded to the revision, and is the default.
     </description>
   </parameter>
+  <parameter name="tag-abbrev">
+    <description>To what length should git describe --tags be abbreviated?
+                 Default: 0
+                 Common other parameter would be 7, which is the 'default'
+                 for "git describe --tags".
+    </description>
+  </param>
   <parameter name="versionprefix">
     <description>Specify a base version as prefix.</description>
   </parameter>

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -100,6 +100,12 @@ class GitTests(GitHgTests, GitSvnTests):
         self.tar_scm_std('--versionformat', "@PARENT_TAG@.@TAG_OFFSET@")
         self.assertTarOnly(self.basename(version=self.rev(2) + ".0"))
 
+    def test_versionformat_parenttag_unshortened(self):
+        # tag-abbrev=7 means using TAG-OFFSET-HASH, EXCEPT when commit == TAG
+        self.tar_scm_std('--versionformat', "@PARENT_TAG@",
+                         '--tag_abbrev=7')
+        self.assertTarOnly(self.basename(version=self.rev(2)))
+
     def _submodule_fixture(self, submod_name):
         fix = self.fixtures
         repo_path = fix.repo_path


### PR DESCRIPTION
[2017/02/04 updated description from new improved commit message]

In order to be able to fully automatically have versions extracted from git so far one could rely on something like @PARENT_TAG@+@TAG_OFFSET@ or @PARENT_TAG@.%cd or any other sort of variation.

Those all work reasonably well, but give strange appearance for the case that the git ref being packages is exactly a tag (first would result in +0, second form still gives a commit date)

@PARENT_TAG@ is implemented by git describe --abbrev=0

This change introduces the capability to instruct the tar_scm service if abbrev should be used (=0) and retain the existing @PARENT_TAG@ behavior or use the new mode (abbrev=7, default for git describe) which in turn results in an automatic version that is "always usable":

* If the commit is a TAG ref: only shows the TAG name
* If the commit is ahead of a TAG-ref, show TAG-TAG_OFFSET-commithash

As `-` is not valid in the rpm version field, it is replaced by `.`