### PR TITLE
Adding http proxy support

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -100,7 +100,7 @@ def is_sslverify_enabled(kwargs):
 def is_proxy_defined():
     """Returns ``True`` if the ``proxy`` option has been enabled or
     not been set (default enabled) ``False`` otherwise."""
-    if os.environ.get('https_proxy') != '': 
+    if os.environ.get('https_proxy') != '':
         return True
     else:
         return False
@@ -108,16 +108,19 @@ def is_proxy_defined():
 
 def define_global_scm_command(scm_type):
     """Sets the global variable ``global_scm_command`` with the proper
-    proxy parameters for each scm, if defined.""" 
+    proxy parameters for each scm, if defined."""
     global svntmpdir
     global global_scm_command
 
-    # git should honor the http[s]_proxy variables, but we need to guarantee this
+    # git should honor the http[s]_proxy variables, but we need to
+    # guarantee this, the variables do not work every time
     if scm_type == 'git':
         global_scm_command = ['git']
         if is_proxy_defined():
-             global_scm_command = ['git','-c','http.proxy=' + os.environ.get('http_proxy'),
-                                   '-c', 'https.proxy=' + os.environ.get('https_proxy')];
+            global_scm_command = ['git', '-c', 'http.proxy=' +
+                                  os.environ.get('http_proxy'),
+                                  '-c', 'https.proxy=' +
+                                  os.environ.get('https_proxy')];
 
     # Subversion requires declaring proxies in a file, as it does not support
     # the http[s]_proxy variables. This creates the temporary config directory
@@ -130,11 +133,11 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M|re.I)
+            regexp_proxy = re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
-                
+
             if (regexp_proxy.group(2) is not None):
                 logging.debug('using proxy port: ' + regexp_proxy.group(2))
                 f.write('http-proxy-port=' + regexp_proxy.group(2) + '\n')
@@ -147,33 +150,38 @@ def define_global_scm_command(scm_type):
                 
                 # for some odd reason subversion expects the domains to have an asterisk
                 for i in range(len(no_proxy_domains[0])):
-                    tmpstr=str(no_proxy_domains[0][i]).strip()
+                    tmpstr = str(no_proxy_domains[0][i]).strip()
                     if tmpstr.startswith('.'):
-                        no_proxy_string+='*' + tmpstr + ','
+                        no_proxy_string += '*' + tmpstr + ','
                 else:
-                    no_proxy_string+=tmpstr + ','
+                    no_proxy_string += tmpstr + ','
 
                 logging.debug('no_proxy string = ' + no_proxy_string)
                 f.write('http-proxy-exceptions=' + no_proxy_string)
                 f.close()
-                global_scm_command=['svn', '--config-dir', svntmpdir, '--non-interactive', '--trust-server-cert']
+                global_scm_command = ['svn', '--config-dir', svntmpdir,
+                                      '--non-interactive', '--trust-server-cert']
             else:
-                global_scm_command=['svn', '--non-interactive', '--trust-server-cert']
+                global_scm_command = ['svn', '--non-interactive',
+                                      '--trust-server-cert']
 
     # Mercurial requires declaring proxies via a --config parameter
     elif scm_type == 'hg':
         global_scm_command = [ 'hg' ];
         if is_proxy_defined():
-            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M | re.I)
-            if (regexp_proxy.group(1) != None):
+            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'),
+                                  re.M | re.I)
+            if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
-                global_scm_command += [ '--config', 'http_proxy.host', regexp_proxy.group(1) ];
-            if (regexp_proxy.group(2) != None):
+                global_scm_command += ['--config', 'http_proxy.host',
+                                       regexp_proxy.group(1)];
+            if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
-                global_scm_command += [ '--config', 'http_proxy.port', regexp_proxy.group(2) ];
-            if (os.environ.get('no_proxy') != None):
+                global_scm_command += ['--config', 'http_proxy.port',
+                                       regexp_proxy.group(2)];
+            if (os.environ.get('no_proxy') is not None):
                 print ('using proxy exceptions: ' + os.environ.get('no_proxy'))
-                global_scm_command += [ '--config', 'no', os.environ.get('no_proxy') ]
+                global_scm_command += ['--config', 'no', os.environ.get('no_proxy')]
 
     # Bazaar honors the http[s]_proxy variables, no action needed
     elif scm_type == 'bzr':
@@ -189,7 +197,8 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via git."""
     
     if not is_sslverify_enabled(kwargs):
-        command = global_scm_command + ['-c', 'http.sslverify=false', 'clone', url, clone_dir]
+        command = global_scm_command + ['-c', 'http.sslverify=false', 'clone',
+                                        url, clone_dir]
     else:
         command = global_scm_command + ['clone', url, clone_dir]
     safe_run(command, cwd=cwd, interactive=sys.stdout.isatty())
@@ -639,7 +648,7 @@ def detect_version_git(args, repodir):
             versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
         else:
             sys.exit("\033[31mNo parent tag present for the checked out "
-                     "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
+                        "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
     if re.match('.*@TAG_OFFSET@.*', versionformat):
         if parent_tag:
@@ -654,7 +663,7 @@ def detect_version_git(args, repodir):
                          output + "\033[0m")
         else:
             sys.exit("\033[31m@TAG_OFFSET@ cannot be expanded, "
-                     "as no parent tag was discovered.\033[0m")
+                        "as no parent tag was discovered.\033[0m")
 
     version = safe_run(global_scm_command + ['log', '-n1', '--date=short',
                         "--pretty=format:%s" % versionformat], repodir)[1]

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -177,7 +177,7 @@ def define_global_scm_command(scm_type):
         if is_proxy_defined():
             regexp_proxy = re.match(r'http://(.*):(.*)',
                                     os.environ.get('http_proxy'), re.M | re.I)
-            if (regexp_proxy.group(1) is not None): 
+            if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
                                        regexp_proxy.group(1)]

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -225,8 +225,8 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
 def fetch_upstream_git_submodules(clone_dir, kwargs):
     """Recursively initialize git submodules."""
     if 'submodules' in kwargs and kwargs['submodules'] == 'enable':
-        safe_run(global_scm_command + ['submodule', 'update', '--init', '--recursive'],
-                 cwd=clone_dir)
+        safe_run(global_scm_command + ['submodule', 'update', '--init', 
+                                       '--recursive'], cwd=clone_dir)
     elif 'submodules' in kwargs and kwargs['submodules'] == 'master':
         safe_run(['git', 'submodule', 'update', '--init', '--recursive',
                  '--remote'], cwd=clone_dir)

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -176,9 +176,8 @@ def define_global_scm_command(scm_type):
         global_scm_command = ['hg']
         if is_proxy_defined():
             regexp_proxy = re.match(r'http://(.*):(.*)',
-                                    os.environ.get('http_proxy'),
-                                    re.M | re.I)
-            if (regexp_proxy.group(1) is not None):
+                                    os.environ.get('http_proxy'), re.M | re.I)
+            if (regexp_proxy.group(1) is not None): 
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
                                        regexp_proxy.group(1)]

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -133,8 +133,9 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = re.match(r'http://(.*):(.*)',
-                                    os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = re.match('http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
@@ -174,8 +175,9 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'hg':
         global_scm_command = ['hg']
         if is_proxy_defined():
-            regexp_proxy = re.match(r'http://(.*):(.*)',
-                                    os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = re.match('http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -133,7 +133,8 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = re.match(r'http://(.*):(.*)', os.environ.get('http_proxy'),
+            regexp_proxy = re.match(r'http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
                                     re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
@@ -144,12 +145,15 @@ def define_global_scm_command(scm_type):
                 f.write('http-proxy-port=' + regexp_proxy.group(2) + '\n')
 
             if (os.environ.get('no_proxy') is not None):
-                logging.debug('using proxy exceptions: ' + os.environ.get('no_proxy'))
+                logging.debug('using proxy exceptions: ' +
+                              os.environ.get('no_proxy'))
                 no_proxy_domains = []
-                no_proxy_domains.append(tuple(os.environ.get('no_proxy').split(",")))
+                no_proxy_domains.append(tuple(os.environ.get(
+                                        'no_proxy').split(",")))
                 no_proxy_string = ""
 
-                # for some odd reason subversion expects the domains to have an asterisk
+                # for some odd reason subversion expects the domains
+                # to have an asterisk
                 for i in range(len(no_proxy_domains[0])):
                     tmpstr = str(no_proxy_domains[0][i]).strip()
                     if tmpstr.startswith('.'):
@@ -161,7 +165,8 @@ def define_global_scm_command(scm_type):
                 f.write('http-proxy-exceptions=' + no_proxy_string)
                 f.close()
                 global_scm_command = ['svn', '--config-dir', svntmpdir,
-                                      '--non-interactive', '--trust-server-cert']
+                                      '--non-interactive',
+                                      '--trust-server-cert']
             else:
                 global_scm_command = ['svn', '--non-interactive',
                                       '--trust-server-cert']
@@ -170,19 +175,22 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'hg':
         global_scm_command = ['hg']
         if is_proxy_defined():
-            regexp_proxy = re.match(r'http://(.*):(.*)', os.environ.get('http_proxy'),
-                                        re.M | re.I)
+            regexp_proxy = re.match(r'http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
-                        regexp_proxy.group(1)]
+                                        regexp_proxy.group(1)]
             if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
                 global_scm_command += ['--config', 'http_proxy.port',
-                        regexp_proxy.group(2)]
+                                        regexp_proxy.group(2)]
             if (os.environ.get('no_proxy') is not None):
-                print ('using proxy exceptions: ' + os.environ.get('no_proxy'))
-                global_scm_command += ['--config', 'no', os.environ.get('no_proxy')]
+                print ('using proxy exceptions: ' +
+                       os.environ.get('no_proxy'))
+                global_scm_command += ['--config', 'no',
+                                       os.environ.get('no_proxy')]
 
     # Bazaar honors the http[s]_proxy variables, no action needed
     elif scm_type == 'bzr':
@@ -190,14 +198,15 @@ def define_global_scm_command(scm_type):
 
 
 def git_ref_exists(clone_dir, revision):
-    rc, _ = run_cmd(global_scm_command + ['rev-parse', '--verify', '--quiet', revision],
+    rc, _ = run_cmd(global_scm_command + ['rev-parse', '--verify',
+                                          '--quiet', revision],
                     cwd=clone_dir, interactive=sys.stdout.isatty())
     return (rc == 0)
 
 
 def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via git."""
-    
+
     if not is_sslverify_enabled(kwargs):
         command = global_scm_command + ['-c', 'http.sslverify=false', 'clone',
                                         url, clone_dir]
@@ -208,20 +217,23 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
     # if the reference does not exist.
     if revision and not git_ref_exists(clone_dir, revision):
         # fetch reference from url and create locally
-        safe_run(global_scm_command + ['fetch', url, revision + ':' + revision],
+        safe_run(global_scm_command + ['fetch', url, revision +
+                                       ':' + revision],
                  cwd=clone_dir, interactive=sys.stdout.isatty())
 
 
 def fetch_upstream_git_submodules(clone_dir, kwargs):
     """Recursively initialize git submodules."""
     if 'submodules' in kwargs and kwargs['submodules']:
-        safe_run(global_scm_command + ['submodule', 'update', '--init', '--recursive'],
+        safe_run(global_scm_command + ['submodule', 'update', '--init',
+                                       '--recursive'],
                  cwd=clone_dir)
 
 
 def fetch_upstream_svn(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via svn."""
-    command = global_scm_command + ['checkout', '--non-interactive', url, clone_dir]
+    command = global_scm_command + ['checkout', '--non-interactive',
+                                    url, clone_dir]
     if revision:
         command.insert(4, '-r%s' % revision)
     if not is_sslverify_enabled(kwargs):
@@ -312,8 +324,8 @@ def switch_revision_git(clone_dir, revision):
     following:
 
     - explicit SHA1: a1b2c3d4....
-    - the SHA1 must be reachable from a default clone/fetch (generally, must be
-      reachable from some branch or tag on the remote).
+    - the SHA1 must be reachable from a default clone/fetch (generally,
+    must be eachable from some branch or tag on the remote).
     - short branch name: "master", "devel" etc.
     - explicit ref: refs/heads/master, refs/tags/v1.2.3,
       refs/changes/49/11249/1
@@ -327,7 +339,8 @@ def switch_revision_git(clone_dir, revision):
         if git_ref_exists(clone_dir, rev):
             found_revision = True
             if os.getenv('OSC_VERSION'):
-                stash_text = safe_run(global_scm_command + ['stash'], cwd=clone_dir)[1]
+                stash_text = safe_run(global_scm_command + ['stash'],
+                                      cwd=clone_dir)[1]
                 text = safe_run(global_scm_command + ['reset', '--hard', rev],
                                 cwd=clone_dir)[1]
                 if stash_text != "No local changes to save\n":
@@ -345,7 +358,8 @@ def switch_revision_git(clone_dir, revision):
     # only update submodules if they have been enabled
     if os.path.exists(
             os.path.join(clone_dir, os.path.join('.git', 'modules'))):
-        safe_run(global_scm_command + ['submodule', 'update', '--recursive'], cwd=clone_dir)
+        safe_run(global_scm_command + ['submodule', 'update', '--recursive'],
+                 cwd=clone_dir)
 
 
 def switch_revision_hg(clone_dir, revision):
@@ -650,7 +664,7 @@ def detect_version_git(args, repodir):
             versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
         else:
             sys.exit("\033[31mNo parent tag present for the checked out "
-                    "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
+                        "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
     if re.match('.*@TAG_OFFSET@.*', versionformat):
         if parent_tag:
@@ -662,10 +676,10 @@ def detect_version_git(args, repodir):
                                         versionformat)
             else:
                 sys.exit("\033[31m@TAG_OFFSET@ can not be expanded: " +
-                         output + "\033[0m")
+                            output + "\033[0m")
         else:
             sys.exit("\033[31m@TAG_OFFSET@ cannot be expanded, "
-                        "as no parent tag was discovered.\033[0m")
+                    "as no parent tag was discovered.\033[0m")
 
     version = safe_run(global_scm_command + ['log', '-n1', '--date=short',
                         "--pretty=format:%s" % versionformat], repodir)[1]
@@ -722,13 +736,15 @@ def detect_version_hg(args, repodir):
     # 'sub(...)' which is only available since 2.4 (first introduced
     # in openSUSE 12.3).
 
-    version = safe_run(global_scm_command + ['log', '-l1', "-r%s" % version.strip(),
+    version = safe_run(global_scm_command + ['log', '-l1', "-r%s" %
+                                             version.strip(),
                         '--template', versionformat], repodir)[1]
     return version_iso_cleanup(version)
 
 
 def detect_version_bzr(args, repodir):
-    """Automatic detection of version number for checked-out BZR repository."""
+    """Automatic detection of version number for checked-out BZR
+    repository."""
     versionformat = args['versionformat']
     if versionformat is None:
         versionformat = '%r'

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -55,8 +55,8 @@ def run_cmd(cmd, cwd, interactive=False, raisesysexit=False):
     env['LANG'] = 'C'
 
     if is_proxy_defined():
-        env['http_proxy'] = os.environ.get('http_proxy');
-        env['https_proxy'] = os.environ.get('https_proxy');
+        env['http_proxy'] = os.environ.get('http_proxy')
+        env['https_proxy'] = os.environ.get('https_proxy')
 
     proc = subprocess.Popen(cmd,
                             shell=False,
@@ -96,16 +96,19 @@ def is_sslverify_enabled(kwargs):
     not been set (default enabled) ``False`` otherwise."""
     return 'sslverify' not in kwargs or kwargs['sslverify']
 
+
 def is_proxy_defined():
     """Returns ``True`` if the ``proxy`` option has been enabled or
     not been set (default enabled) ``False`` otherwise."""
     if os.environ.get('https_proxy') != '': 
-         return True
+        return True
     else:
-         return False
+        return False
+
 
 def define_global_scm_command(scm_type):
-    """Sets the global variable ``global_scm_command`` with the proper proxy parameters for each scm, if defined.""" 
+    """Sets the global variable ``global_scm_command`` with the proper
+    proxy parameters for each scm, if defined.""" 
     global svntmpdir
     global global_scm_command
 
@@ -113,31 +116,35 @@ def define_global_scm_command(scm_type):
     if scm_type == 'git':
         global_scm_command = ['git']
         if is_proxy_defined():
-             global_scm_command = ['git','-c','http.proxy=' + os.environ.get('http_proxy'), '-c', 'https.proxy=' + os.environ.get('https_proxy')];
+             global_scm_command = ['git','-c','http.proxy=' + os.environ.get('http_proxy'),
+                                   '-c', 'https.proxy=' + os.environ.get('https_proxy')];
 
-    # Subversion requires declaring proxies in a file, as it does not support the http[s]_proxy variables
-    # this creates the temporary config directory that will be added via '--config-dir'
+    # Subversion requires declaring proxies in a file, as it does not support
+    # the http[s]_proxy variables. This creates the temporary config directory
+    # that will be added via '--config-dir'
     elif scm_type == 'svn':
 
         if is_proxy_defined():
-            svntmpdir=tempfile.mkdtemp()
+            svntmpdir = tempfile.mkdtemp()
             logging.debug("using " + svntmpdir)
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M|re.I)
-            if (regexp_proxy.group(1) != None):
-                logging.debug ('using proxy host: ' + regexp_proxy.group(1))
+            regexp_proxy = re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M|re.I)
+            if (regexp_proxy.group(1) is not None):
+                logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
-            if (regexp_proxy.group(2) != None):
+                
+            if (regexp_proxy.group(2) is not None):
                 logging.debug('using proxy port: ' + regexp_proxy.group(2))
                 f.write('http-proxy-port=' + regexp_proxy.group(2) + '\n')
 
-            if (os.environ.get('no_proxy') != None):
+            if (os.environ.get('no_proxy') is not None):
                 logging.debug('using proxy exceptions: ' + os.environ.get('no_proxy'))
-                no_proxy_domains=[]
+                no_proxy_domains = []
                 no_proxy_domains.append(tuple(os.environ.get('no_proxy').split(",")))
-                no_proxy_string=""
+                no_proxy_string = ""
+                
                 # for some odd reason subversion expects the domains to have an asterisk
                 for i in range(len(no_proxy_domains[0])):
                     tmpstr=str(no_proxy_domains[0][i]).strip()
@@ -157,7 +164,7 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'hg':
         global_scm_command = [ 'hg' ];
         if is_proxy_defined():
-            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M|re.I)
+            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) != None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += [ '--config', 'http_proxy.host', regexp_proxy.group(1) ];
@@ -172,8 +179,9 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'bzr':
         global_scm_command = ['bzr']
 
+
 def git_ref_exists(clone_dir, revision):
-    rc, _ = run_cmd(global_scm_command + [ 'rev-parse', '--verify', '--quiet', revision],
+    rc, _ = run_cmd(global_scm_command + ['rev-parse', '--verify', '--quiet', revision],
                     cwd=clone_dir, interactive=sys.stdout.isatty())
     return (rc == 0)
 
@@ -181,9 +189,9 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via git."""
     
     if not is_sslverify_enabled(kwargs):
-    	command = global_scm_command + [ '-c', 'http.sslverify=false', 'clone', url, clone_dir]
+        command = global_scm_command + ['-c', 'http.sslverify=false', 'clone', url, clone_dir]
     else:
-    	command = global_scm_command + [ 'clone', url, clone_dir]
+        command = global_scm_command + ['clone', url, clone_dir]
     safe_run(command, cwd=cwd, interactive=sys.stdout.isatty())
 
     # if the reference does not exist.
@@ -202,7 +210,7 @@ def fetch_upstream_git_submodules(clone_dir, kwargs):
 
 def fetch_upstream_svn(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via svn."""
-    command = global_scm_command + [ 'checkout', '--non-interactive', url, clone_dir]
+    command = global_scm_command + ['checkout', '--non-interactive', url, clone_dir]
     if revision:
         command.insert(4, '-r%s' % revision)
     if not is_sslverify_enabled(kwargs):
@@ -221,7 +229,7 @@ def fetch_upstream_hg(url, clone_dir, revision, cwd, kwargs):
 
 def fetch_upstream_bzr(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources from bzr."""
-    command = global_scm_command + [ 'checkout', url, clone_dir]
+    command = global_scm_command + ['checkout', url, clone_dir]
     if revision:
         command.insert(3, '-r')
         command.insert(4, revision)

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -134,8 +134,7 @@ def define_global_scm_command(scm_type):
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
             regexp_proxy = re.match(r'http://(.*):(.*)',
-                                    os.environ.get('http_proxy'),
-                                    re.M | re.I)
+                                    os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -134,8 +134,7 @@ def define_global_scm_command(scm_type):
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
             regexp_proxy = re.match('http://(.*):(.*)',
-                                    os.environ.get('http_proxy'),
-                                    re.M | re.I)
+                                    os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
@@ -176,8 +175,7 @@ def define_global_scm_command(scm_type):
         global_scm_command = ['hg']
         if is_proxy_defined():
             regexp_proxy = re.match('http://(.*):(.*)',
-                                    os.environ.get('http_proxy'),
-                                    re.M | re.I)
+                                    os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -120,7 +120,7 @@ def define_global_scm_command(scm_type):
             global_scm_command = ['git', '-c', 'http.proxy=' +
                                   os.environ.get('http_proxy'),
                                   '-c', 'https.proxy=' +
-                                  os.environ.get('https_proxy')];
+                                  os.environ.get('https_proxy')]
 
     # Subversion requires declaring proxies in a file, as it does not support
     # the http[s]_proxy variables. This creates the temporary config directory
@@ -133,7 +133,8 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = re.match(r'http://(.*):(.*)', os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
@@ -147,7 +148,7 @@ def define_global_scm_command(scm_type):
                 no_proxy_domains = []
                 no_proxy_domains.append(tuple(os.environ.get('no_proxy').split(",")))
                 no_proxy_string = ""
-                
+
                 # for some odd reason subversion expects the domains to have an asterisk
                 for i in range(len(no_proxy_domains[0])):
                     tmpstr = str(no_proxy_domains[0][i]).strip()
@@ -167,18 +168,18 @@ def define_global_scm_command(scm_type):
 
     # Mercurial requires declaring proxies via a --config parameter
     elif scm_type == 'hg':
-        global_scm_command = [ 'hg' ];
+        global_scm_command = ['hg']
         if is_proxy_defined():
-            regexp_proxy=re.match( r'http://(.*):(.*)', os.environ.get('http_proxy'),
-                                  re.M | re.I)
+            regexp_proxy = re.match(r'http://(.*):(.*)', os.environ.get('http_proxy'),
+                                        re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
-                                       regexp_proxy.group(1)];
+                        regexp_proxy.group(1)]
             if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
                 global_scm_command += ['--config', 'http_proxy.port',
-                                       regexp_proxy.group(2)];
+                        regexp_proxy.group(2)]
             if (os.environ.get('no_proxy') is not None):
                 print ('using proxy exceptions: ' + os.environ.get('no_proxy'))
                 global_scm_command += ['--config', 'no', os.environ.get('no_proxy')]
@@ -192,6 +193,7 @@ def git_ref_exists(clone_dir, revision):
     rc, _ = run_cmd(global_scm_command + ['rev-parse', '--verify', '--quiet', revision],
                     cwd=clone_dir, interactive=sys.stdout.isatty())
     return (rc == 0)
+
 
 def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
     """Fetch sources via git."""
@@ -648,16 +650,16 @@ def detect_version_git(args, repodir):
             versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
         else:
             sys.exit("\033[31mNo parent tag present for the checked out "
-                        "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
+                    "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
     if re.match('.*@TAG_OFFSET@.*', versionformat):
         if parent_tag:
             rc, output = run_cmd(global_scm_command + ['rev-list', '--count',
-                                  parent_tag + '..HEAD'], repodir)
+                                    parent_tag + '..HEAD'], repodir)
             if not rc:
                 tag_offset = output.strip()
                 versionformat = re.sub('@TAG_OFFSET@', tag_offset,
-                                       versionformat)
+                                        versionformat)
             else:
                 sys.exit("\033[31m@TAG_OFFSET@ can not be expanded: " +
                          output + "\033[0m")
@@ -720,7 +722,7 @@ def detect_version_hg(args, repodir):
     # 'sub(...)' which is only available since 2.4 (first introduced
     # in openSUSE 12.3).
 
-    version = safe_run(global_scm_command +  ['log', '-l1', "-r%s" % version.strip(),
+    version = safe_run(global_scm_command + ['log', '-l1', "-r%s" % version.strip(),
                         '--template', versionformat], repodir)[1]
     return version_iso_cleanup(version)
 

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -133,8 +133,9 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = re.match('http://(.*):(.*)',
-                                    os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = \
+                re.match('http://(.*):(.*)',
+                         os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
@@ -174,8 +175,9 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'hg':
         global_scm_command = ['hg']
         if is_proxy_defined():
-            regexp_proxy = re.match('http://(.*):(.*)',
-                                    os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = \
+                re.match('http://(.*):(.*)',
+                         os.environ.get('http_proxy'), re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -181,11 +181,11 @@ def define_global_scm_command(scm_type):
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
-                                        regexp_proxy.group(1)]
+                                    regexp_proxy.group(1)]
             if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
                 global_scm_command += ['--config', 'http_proxy.port',
-                                        regexp_proxy.group(2)]
+                                    regexp_proxy.group(2)]
             if (os.environ.get('no_proxy') is not None):
                 print ('using proxy exceptions: ' +
                        os.environ.get('no_proxy'))
@@ -664,12 +664,13 @@ def detect_version_git(args, repodir):
             versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
         else:
             sys.exit("\033[31mNo parent tag present for the checked out "
-                        "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
+                    "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
     if re.match('.*@TAG_OFFSET@.*', versionformat):
         if parent_tag:
-            rc, output = run_cmd(global_scm_command + ['rev-list', '--count',
-                                    parent_tag + '..HEAD'], repodir)
+            rc, output = run_cmd(global_scm_command +
+                                 ['rev-list', '--count', parent_tag +
+                                  '..HEAD'], repodir)
             if not rc:
                 tag_offset = output.strip()
                 versionformat = re.sub('@TAG_OFFSET@', tag_offset,
@@ -681,7 +682,8 @@ def detect_version_git(args, repodir):
             sys.exit("\033[31m@TAG_OFFSET@ cannot be expanded, "
                     "as no parent tag was discovered.\033[0m")
 
-    version = safe_run(global_scm_command + ['log', '-n1', '--date=short',
+    version = safe_run(global_scm_command +
+                       ['log', '-n1', '--date=short',
                         "--pretty=format:%s" % versionformat], repodir)[1]
     return version_iso_cleanup(version)
 
@@ -736,8 +738,9 @@ def detect_version_hg(args, repodir):
     # 'sub(...)' which is only available since 2.4 (first introduced
     # in openSUSE 12.3).
 
-    version = safe_run(global_scm_command + ['log', '-l1', "-r%s" %
-                                             version.strip(),
+    version = safe_run(global_scm_command +
+                       ['log', '-l1', "-r%s" %
+                        version.strip(),
                         '--template', versionformat], repodir)[1]
     return version_iso_cleanup(version)
 
@@ -773,7 +776,8 @@ def get_timestamp_tar(repodir):
 
 
 def get_timestamp_bzr(repodir):
-    log = safe_run(global_scm_command + ['log', '--limit=1', '--log-format=long'],
+    log = safe_run(global_scm_command +
+                   ['log', '--limit=1', '--log-format=long'],
                    repodir)[1]
     match = re.search(r'timestamp:(.*)', log, re.MULTILINE)
     if not match:

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -133,9 +133,9 @@ def define_global_scm_command(scm_type):
             CLEANUP_DIRS.append(svntmpdir)
             f = open(svntmpdir + "/servers", "wb")
             f.write('[global]\n')
-            regexp_proxy = \
-                re.match('http://(.*):(.*)',
-                         os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = re.match('http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 logging.debug('using proxy host: ' + regexp_proxy.group(1))
                 f.write('http-proxy-host=' + regexp_proxy.group(1) + '\n')
@@ -175,9 +175,9 @@ def define_global_scm_command(scm_type):
     elif scm_type == 'hg':
         global_scm_command = ['hg']
         if is_proxy_defined():
-            regexp_proxy = \
-                re.match('http://(.*):(.*)',
-                         os.environ.get('http_proxy'), re.M | re.I)
+            regexp_proxy = re.match('http://(.*):(.*)',
+                                    os.environ.get('http_proxy'),
+                                    re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -181,11 +181,11 @@ def define_global_scm_command(scm_type):
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
                 global_scm_command += ['--config', 'http_proxy.host',
-                                    regexp_proxy.group(1)]
+                                       regexp_proxy.group(1)]
             if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
                 global_scm_command += ['--config', 'http_proxy.port',
-                                    regexp_proxy.group(2)]
+                                       regexp_proxy.group(2)]
             if (os.environ.get('no_proxy') is not None):
                 print ('using proxy exceptions: ' +
                        os.environ.get('no_proxy'))
@@ -367,8 +367,9 @@ def switch_revision_hg(clone_dir, revision):
     if revision is None:
         revision = 'tip'
 
-    rc, _  = run_cmd(global_scm_command + ['update', revision], cwd=clone_dir,
-                     interactive=sys.stdout.isatty())
+    rc, _ = run_cmd(global_scm_command + ['update', revision],
+                    cwd=clone_dir,
+                    interactive=sys.stdout.isatty())
     if rc:
         sys.exit('%s: No such revision' % revision)
 
@@ -664,7 +665,7 @@ def detect_version_git(args, repodir):
             versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
         else:
             sys.exit("\033[31mNo parent tag present for the checked out "
-                    "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
+                     "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
     if re.match('.*@TAG_OFFSET@.*', versionformat):
         if parent_tag:
@@ -674,13 +675,13 @@ def detect_version_git(args, repodir):
             if not rc:
                 tag_offset = output.strip()
                 versionformat = re.sub('@TAG_OFFSET@', tag_offset,
-                                        versionformat)
+                                       versionformat)
             else:
                 sys.exit("\033[31m@TAG_OFFSET@ can not be expanded: " +
-                            output + "\033[0m")
+                         output + "\033[0m")
         else:
             sys.exit("\033[31m@TAG_OFFSET@ cannot be expanded, "
-                    "as no parent tag was discovered.\033[0m")
+                     "as no parent tag was discovered.\033[0m")
 
     version = safe_run(global_scm_command +
                        ['log', '-n1', '--date=short',
@@ -1111,8 +1112,9 @@ def get_svn_log(repodir, revision1, revision2):
 
 
 def get_svn_rev(repodir, num_commits):
-    revisions = safe_run(global_scm_command + ['log', '-l%d' % num_commits, '-q',
-                         '--incremental'], cwd=repodir)[1].split('\n')
+    revisions = safe_run(global_scm_command +
+                         ['log', '-l%d' % num_commits, '-q', '--incremental'],
+                         cwd=repodir)[1].split('\n')
     # remove blank entry on end
     revisions.pop()
     # return last entry
@@ -1446,7 +1448,8 @@ def singletask(use_obs_scm, args):
     if use_obs_scm:
         commit = None
         if args.scm == "git":
-            commit = safe_run(global_scm_command + ['rev-parse', 'HEAD'], clone_dir)[1]
+            commit = safe_run(global_scm_command +
+                              ['rev-parse', 'HEAD'], clone_dir)[1]
         create_cpio(tar_dir, basename, dstname, version, commit, args)
     else:
         create_tar(tar_dir, args.outdir,

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -225,7 +225,7 @@ def fetch_upstream_git(url, clone_dir, revision, cwd, kwargs):
 def fetch_upstream_git_submodules(clone_dir, kwargs):
     """Recursively initialize git submodules."""
     if 'submodules' in kwargs and kwargs['submodules'] == 'enable':
-        safe_run(global_scm_command + ['submodule', 'update', '--init', 
+        safe_run(global_scm_command + ['submodule', 'update', '--init',
                                        '--recursive'], cwd=clone_dir)
     elif 'submodules' in kwargs and kwargs['submodules'] == 'master':
         safe_run(['git', 'submodule', 'update', '--init', '--recursive',

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -180,17 +180,17 @@ def define_global_scm_command(scm_type):
                                     re.M | re.I)
             if (regexp_proxy.group(1) is not None):
                 print ('using proxy host: ' + regexp_proxy.group(1))
-                global_scm_command += ['--config', 'http_proxy.host',
+                global_scm_command += ['--config=http_proxy.host=' +
                                        regexp_proxy.group(1)]
             if (regexp_proxy.group(2) is not None):
                 print ('using proxy port: ' + regexp_proxy.group(2))
-                global_scm_command += ['--config', 'http_proxy.port',
+                global_scm_command += ['--config=http_proxy.port=' +
                                        regexp_proxy.group(2)]
             if (os.environ.get('no_proxy') is not None):
                 print ('using proxy exceptions: ' +
                        os.environ.get('no_proxy'))
-                global_scm_command += ['--config', 'no',
-                                       os.environ.get('no_proxy')]
+                global_scm_command += ['--config=http_proxy.no=\"' +
+                                       os.environ.get('no_proxy') + "\""]
 
     # Bazaar honors the http[s]_proxy variables, no action needed
     elif scm_type == 'bzr':
@@ -1036,6 +1036,7 @@ def write_changes(changes_filename, changes, version, author):
 
 def _git_log_cmd(cmd_args, repodir, subdir):
     """ Helper function to call 'git log' with args"""
+    define_global_scm_command('git')
     cmd = global_scm_command + ['log'] + cmd_args
     if subdir:
         cmd += ['--', subdir]

--- a/tests/bzrtests.py
+++ b/tests/bzrtests.py
@@ -2,7 +2,7 @@
 
 from commontests import CommonTests
 from bzrfixtures import BzrFixtures
-from utils       import run_bzr
+from utils import run_bzr
 
 
 class BzrTests(CommonTests):
@@ -14,9 +14,9 @@ class BzrTests(CommonTests):
     """
 
     scm = 'bzr'
-    initial_clone_command = 'bzr checkout'
-    update_cache_command  = 'bzr update'
-    sslverify_false_args  = '-Ossl.cert_reqs=None'
+    sslverify_false_args = '-Ossl.cert_reqs=None'
+    initial_clone_command = 'bzr.*checkout'
+    update_cache_command = 'bzr.*update'
     fixtures_class = BzrFixtures
 
     def default_version(self):

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -6,10 +6,10 @@ import re
 import tarfile
 import textwrap
 
-from githgtests  import GitHgTests
+from githgtests import GitHgTests
 from gitsvntests import GitSvnTests
 from gitfixtures import GitFixtures
-from utils       import run_git
+from utils import run_git
 
 
 class GitTests(GitHgTests, GitSvnTests):
@@ -21,14 +21,14 @@ class GitTests(GitHgTests, GitSvnTests):
     """
 
     scm = 'git'
-    initial_clone_command = 'git clone'
-    update_cache_command  = 'git fetch'
-    sslverify_false_args  = '--config http.sslverify=false'
+    sslverify_false_args = '-c http.sslverify=false'
+    initial_clone_command = 'git.*clone'
+    update_cache_command = 'git.*fetch'
     fixtures_class = GitFixtures
 
     abbrev_hash_format = '%h'
-    timestamp_format   = '%ct'
-    yyyymmdd_format    = '%cd'
+    timestamp_format = '%ct'
+    yyyymmdd_format = '%cd'
     yyyymmddhhmmss_format = '%ci'
 
     def default_version(self):

--- a/tests/svntests.py
+++ b/tests/svntests.py
@@ -19,7 +19,7 @@ class SvnTests(GitSvnTests):
 
     scm = 'svn'
     initial_clone_command = 'svn.*(co|checkout) '
-    update_cache_command = 'svn up(date)?'
+    update_cache_command = 'svn.*up(date)?'
     sslverify_false_args = '--trust-server-cert'
     fixtures_class = SvnFixtures
 

--- a/tests/svntests.py
+++ b/tests/svntests.py
@@ -6,7 +6,7 @@ import textwrap
 
 from gitsvntests import GitSvnTests
 from svnfixtures import SvnFixtures
-from utils       import run_svn
+from utils import run_svn
 
 
 class SvnTests(GitSvnTests):
@@ -18,9 +18,9 @@ class SvnTests(GitSvnTests):
     """
 
     scm = 'svn'
-    initial_clone_command = 'svn (co|checkout) '
-    update_cache_command  = 'svn up(date)?'
-    sslverify_false_args  = '--trust-server-cert'
+    initial_clone_command = 'svn.*(co|checkout) '
+    update_cache_command = 'svn up(date)?'
+    sslverify_false_args = '--trust-server-cert'
     fixtures_class = SvnFixtures
 
     def default_version(self):

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -128,10 +128,10 @@ class TestAssertions(unittest.TestCase):
 
         if dirents[0][-4:] == '.tar':
             tar = dirents[0]
-            wd  = dirents[1]
+            wd = dirents[1]
         elif dirents[1][-4:] == '.tar':
             tar = dirents[1]
-            wd  = dirents[0]
+            wd = dirents[0]
         else:
             self.fail('no .tar found in ' + self.outdir)
 
@@ -151,9 +151,8 @@ class TestAssertions(unittest.TestCase):
 
     def assertSSLVerifyFalse(self, logpath, loglines):
         self._find(logpath, loglines,
-                   self.initial_clone_command +
-                   '.*' + self.sslverify_false_args,
-                   self.sslverify_false_args + 'true')
+                   self.initial_clone_command,
+                   self.sslverify_false_args)
 
     def assertRanUpdate(self, logpath, loglines):
         self._find(logpath, loglines,

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -31,21 +31,21 @@ class UnitTestCases(unittest.TestCase):
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_with_args(self, safe_run_mock):
-        global_scm_command = define_global_scm_command('git')
+        global_scm_command = define_global_scm_command('git', False)
         new_cmd = _git_log_cmd(['-n1'], None, '')
         safe_run_mock.assert_called_once_with(global_scm_command +
                                               ['log', '-n1'], cwd=None)
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_without_args(self, safe_run_mock):
-        global_scm_command = define_global_scm_command('git')
+        global_scm_command = define_global_scm_command('git', False)
         new_cmd = _git_log_cmd([], None, '')
         safe_run_mock.assert_called_once_with(global_scm_command +
                                               ['log'], cwd=None)
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_with_subdir(self, safe_run_mock):
-        global_scm_command = define_global_scm_command('git')
+        global_scm_command = define_global_scm_command('git', False)
         new_cmd = _git_log_cmd(['-n1'], None, 'subdir')
         safe_run_mock.assert_called_once_with(global_scm_command +
                                               ['log', '-n1', '--', 'subdir'],

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -7,6 +7,8 @@ from mock import patch
 
 from tar_scm import _calc_dir_to_clone_to
 from tar_scm import _git_log_cmd
+from tar_scm import is_proxy_defined
+from tar_scm import define_global_scm_command
 
 
 class UnitTestCases(unittest.TestCase):
@@ -29,16 +31,22 @@ class UnitTestCases(unittest.TestCase):
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_with_args(self, safe_run_mock):
+        global_scm_command = define_global_scm_command('git')
         new_cmd = _git_log_cmd(['-n1'], None, '')
-        safe_run_mock.assert_called_once_with(['git', 'log', '-n1'], cwd=None)
+        safe_run_mock.assert_called_once_with(global_scm_command +
+                                              ['log', '-n1'], cwd=None)
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_without_args(self, safe_run_mock):
+        global_scm_command = define_global_scm_command('git')
         new_cmd = _git_log_cmd([], None, '')
-        safe_run_mock.assert_called_once_with(['git', 'log'], cwd=None)
+        safe_run_mock.assert_called_once_with(global_scm_command +
+                                              ['log'], cwd=None)
 
     @patch('tar_scm.safe_run')
     def test__git_log_cmd_with_subdir(self, safe_run_mock):
+        global_scm_command = define_global_scm_command('git')
         new_cmd = _git_log_cmd(['-n1'], None, 'subdir')
-        safe_run_mock.assert_called_once_with(['git', 'log', '-n1',
-                                               '--', 'subdir'], cwd=None)
+        safe_run_mock.assert_called_once_with(global_scm_command +
+                                              ['log', '-n1', '--', 'subdir'],
+                                              cwd=None)


### PR DESCRIPTION
These changes add support for using HTTP proxies with GIT, SVN, HG and BZR, according to each one's particular requirements:
- git needs to have some variables redefined for each run
- svn needs a temporary config file for each run
- hg needs some command line parameters for each run
- bzr seems to honour the http[s]_proxy variables.

I needed this to be able to use tar_scm inside a private instance of OBS behind a corporate firewall in a customer's site.

I did it by defining a "global_scm_command" variable with each particular SCM needs, and altering all safe_run() calls to use it.
