### PR TITLE
Add --stripversionprefix parameter for git tags

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -571,6 +571,11 @@ def detect_version_git(args, repodir):
 
     version = safe_run(['git', 'log', '-n1', '--date=short',
                         "--pretty=format:%s" % versionformat], repodir)[1]
+
+    if 'stripversionprefix' in args and args['stripversionprefix'] is not None:
+        if version.startswith(args['stripversionprefix']):
+            version = version[len(args['stripversionprefix']):]
+
     return version_iso_cleanup(version)
 
 
@@ -1095,6 +1100,8 @@ def parse_args():
                         help='Specify a base version as prefix.')
     parser.add_argument('--parent-tag',
                         help='Override base commit for @TAG_OFFSET@')
+    parser.add_argument('--stripversionprefix',
+                        help='Strip prefix string from git tag.')
     parser.add_argument('--revision',
                         help='Specify revision to package')
     parser.add_argument('--extract', action='append',

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -70,6 +70,13 @@
       computing @TAG_OFFSET@.
     </description>
   </parameter>
+  <parameter name="stripversionprefix">
+    <description>
+       Strip the prefix string from the git tag.
+       Useful when using @PARENT_TAG@ and upstream prefixes "v" or "release"
+       to the tag, and the generated package version should not include them.
+    </description>
+  </parameter>
   <parameter name="revision">
     <description>
        Specify revision of source to check out.

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -100,6 +100,16 @@ class GitTests(GitHgTests, GitSvnTests):
         self.tar_scm_std('--versionformat', "@PARENT_TAG@.@TAG_OFFSET@")
         self.assertTarOnly(self.basename(version=self.rev(2) + ".0"))
 
+    def test_stripversionprefix(self):
+        self.tar_scm_std("--versionformat", "remove@PARENT_TAG@remove",
+                         "--stripversionprefix", "remove")
+        self.assertTarOnly(self.basename(version=self.rev(2)) + "remove")
+
+        self.tar_scm_std("--versionformat", "keep@PARENT_TAG@remove",
+                         "--stripversionprefix", "remove")
+        self.assertTarOnly(self.basename(version="keep" + self.rev(2)) +
+                           "remove")
+
     def _submodule_fixture(self, submod_name):
         fix = self.fixtures
         repo_path = fix.repo_path


### PR DESCRIPTION
Adds a new "stripversionprefix" parameter that takes a string and
strips it from the git tag starting from the left, if it exists.
Useful when using @PARENT_TAG@ and upstream prefixes "v" or "release"
to the tag, and the generated package version should not include them.

I am facing this issue so I've put together a diff following suggestions in https://github.com/openSUSE/obs-service-tar_scm/pull/100#issuecomment-231048860
Fixes #92 
