### PR TITLE
Reconverge with OBS [part 1]

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-tar-scm
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 8.0.0), bzr, git, mercurial, pep8, python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil, python-unittest2, subversion
+Build-Depends: debhelper (>= 8.0.0), bzr, git, pep8, python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil, python-unittest2, subversion
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-tar_scm
 X-Python-Version: >= 2.6
@@ -10,7 +10,8 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, mercurial, subversion, cpio
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio
+Recommends: mercurial
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-tar-scm
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 8.0.0), bzr, git, pep8, python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil, python-unittest2, subversion
+Build-Depends: debhelper (>= 7.0.0), python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-tar_scm
 X-Python-Version: >= 2.6

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil
 Recommends: mercurial
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.

--- a/debian/rules
+++ b/debian/rules
@@ -9,5 +9,7 @@ DESTDIR=debian/obs-service-tar-scm
 
 override_dh_auto_build: ;
 
+override_dh_auto_test: ;
+
 override_dh_auto_install:
 	$(MAKE) DESTDIR=`pwd`/$(DESTDIR) PREFIX=/usr install

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -456,7 +456,8 @@ def create_tar(repodir, outdir, dstname, extension='tar',
         """Python 2.7 only: reset uid/gid to 0/0 (root)."""
         tarinfo.uid = tarinfo.gid = 0
         tarinfo.uname = tarinfo.gname = "root"
-        tarinfo.mtime = timestamp
+        if timestamp != 0:
+            tarinfo.mtime = timestamp
         return tarinfo
 
     def tar_filter(tarinfo):

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1190,7 +1190,15 @@ def parse_args():
 
 
 def get_repocachedir():
-    # check for enabled caches (1. environment, 2. user config, 3. system wide)
+    # check for enabled caches in this order (first wins):
+    #   1. local .cache
+    #   2. environment
+    #   3. user config
+    #   4. system wide
+    cwd = os.getcwd()
+    if os.path.isdir(os.path.join(cwd, '.cache')):
+        return os.path.join(cwd, '.cache')
+
     repocachedir = os.getenv('CACHEDIRECTORY')
     if repocachedir is None:
         config = get_config_options()

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1260,7 +1260,13 @@ def singletask(use_obs_scm, args):
 
     repodir = None
     # construct repodir (the parent directory of the checkout)
-    if repocachedir and os.path.isdir(os.path.join(repocachedir, 'repo')):
+    if repocachedir and os.path.isdir(repocachedir):
+        # construct subdirs on very first run
+        if not os.path.isdir(os.path.join(repocachedir, 'repo')):
+            os.mkdir(os.path.join(repocachedir, 'repo'))
+        if not os.path.isdir(os.path.join(repocachedir, 'incoming')):
+            os.mkdir(os.path.join(repocachedir, 'incoming'))
+
         repohash = get_repocache_hash(args.scm, args.url, args.subdir)
         logging.debug("HASH: %s", repohash)
         repodir = os.path.join(repocachedir, 'repo')


### PR DESCRIPTION
This is the first in a series of PRs to reconverge the codebase with the currently live code in OBS, which is represented by the changes in #123.  This PR just has the first 7 commits of that PR, with one small tweak to break a long comment line which was causing `make check`'s PEP8 test to fail.