### PR TITLE
GPG signature verification

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -1213,11 +1213,19 @@ def parse_args():
     parser.add_argument('--history-depth',
                         help='Obsolete osc service parameter that does '
                              'nothing')
+    parser.add_argument('--verify-revision-key', default='',
+                        help='Specify GPG public key to use for verification'
+			     'of the source revision')
     args = parser.parse_args()
 
     # basic argument validation
     if not os.path.isdir(args.outdir):
         sys.exit("%s: No such directory" % args.outdir)
+
+    if (args.verify_revision_key
+                      and not (os.path.isfile(args.verify_revision_key)
+                               or os.path.isabs(args.verify_revision_key))):
+        sys.exit("%s: Missing or relative key path" % args.verify_revision_key)
 
     args.outdir = os.path.abspath(args.outdir)
     orig_subdir = args.subdir
@@ -1340,6 +1348,9 @@ def singletask(use_obs_scm, args):
         repodir = os.getcwd()
 
     clone_dir = scm_object.fetch_upstream(out_dir=repodir, **args.__dict__)
+
+    if args.verify_revision_key:
+	    scm_object.verify_repo(clone_dir, args.verify_revision_key)
 
     if args.filename:
         dstname = basename = args.filename

--- a/tar_scm.py
+++ b/tar_scm.py
@@ -555,7 +555,7 @@ class TarSCM:
     ### END class TarSCM.tar
 
     class helpers():
-        def run_cmd(self, cmd, cwd, interactive=False, raisesysexit=False):
+        def run_cmd(self, cmd, cwd, interactive=False, raisesysexit=False, env=None):
             """Execute the command cmd in the working directory cwd and check return
             value. If the command returns non-zero and raisesysexit is True raise a
             SystemExit exception otherwise return a tuple of return code and command
@@ -563,9 +563,10 @@ class TarSCM:
             """
             logging.debug("COMMAND: %s", cmd)
 
+            if env is None:
+                env = os.environ.copy()
             # Ensure we get predictable results when parsing the output of commands
             # like 'git branch'
-            env = os.environ.copy()
             env['LANG'] = 'C'
 
             proc = subprocess.Popen(cmd,

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -134,4 +134,7 @@ which get maintained in the SCM. Can be used multiple times.</description>
   <parameter name="changesauthor">
     <description>Specify author of the changes file entry to be written.  Defaults to first email entry in ~/.oscrc, or "opensuse-packaging@opensuse.org" if there is no .oscrc found.</description>
   </parameter>
+  <parameter name="verify-revision-key">
+    <description>Specify a key file for GPG verification of the given source revision.  GPG revision verification is only supported by git, and is disabled by default.  'revision' must directly correspond to a signed git tag.</description>
+  </parameter>
 </service>

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,6 +21,8 @@ class Fixtures:
     COMMITTER_DATE = int(1234567890)
 
     def __init__(self, container_dir, scmlogs):
+        self.user_name  = 'test'
+        self.user_email = 'test@test.com'
         self.container_dir = container_dir
         self.scmlogs       = scmlogs
         self.repo_path     = self.container_dir + '/repo'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,8 @@
 
 import os
 import shutil
+import re
+from utils import run_cmd
 
 
 class Fixtures:
@@ -27,12 +29,17 @@ class Fixtures:
         self.scmlogs       = scmlogs
         self.repo_path     = self.container_dir + '/repo'
         self.repo_url      = 'file://' + self.repo_path
+        self.gpg_dir       = None
+        self.gpg_key_id    = None
 
         # Keys are stringified integers representing commit sequence numbers;
         # values can be passed to --revision
         self.revs = {}
 
     def safe_run(self, cmd):
+        if self.gpg_dir != None:
+            os.putenv('GNUPGHOME', self.gpg_dir)
+
         stdout, stderr, exitcode = self.run(cmd)
         if exitcode != 0:
             raise RuntimeError("Command failed; aborting.")
@@ -137,3 +144,64 @@ class Fixtures:
         self.do_commit(wd, new_rev, newly_created)
         self.record_rev(wd, new_rev)
         self.scmlogs.annotate("Created 1 commit; now at %s" % (new_rev))
+
+    def create_gpg_key(self):
+
+        if self.gpg_dir:
+            print 'GPG state already initialised'
+            return (self.gpg_dir, self.gpg_key_id)
+
+        batch_script = '''
+            %echo starting keygen
+            Key-Type: default
+            Subkey-Type: default
+            Name-Real: ''' + self.user_name + '''
+            Name-Comment: test user
+            Name-Email: ''' + self.user_email + '''
+            Expire-Date: 1d
+            %no-protection
+            %transient-key
+            %commit
+            %echo done'''
+
+        # create a dir to use as GNUPGHOME for key import and verification
+        gpg_dir = self.container_dir + "/gpg"
+        os.makedirs(gpg_dir)
+        batch_path = gpg_dir + "/batch_script.txt"
+
+        with open(batch_path, "w") as text_file:
+            text_file.write(batch_script)
+
+        cmd = 'gpg --homedir %s --gen-key --batch %s' % (gpg_dir, batch_path)
+        (stdout, stderr, ret) = run_cmd(cmd)
+        if ret != 0:
+            print "GPG key creation failed: ", stderr
+            return (None, None)
+
+        cmd = 'gpg --homedir %s --keyid-format LONG --list-secret-keys' \
+                % (gpg_dir)
+
+        (stdout, stderr, ret) = run_cmd(cmd)
+        if ret != 0:
+            print "GPG key list failed: ", stderr
+            return (None, None)
+
+        m = re.search('sec\s+\w+/(\w+)', stdout)
+        if m == None or m.group(1) == None:
+            print "couldn't find GPG key ID in ", stdout
+            return (None, None)
+
+        gpg_key_id = m.group(1)
+
+        print "created GPG keypair at %s with key id %s" % (gpg_dir, gpg_key_id)
+        self.gpg_dir = gpg_dir
+        self.gpg_key_id = gpg_key_id
+        return (gpg_dir, gpg_key_id)
+
+    def delete_gpg_key(self):
+        if self.gpg_dir == None:
+            return
+
+        shutil.rmtree(self.gpg_dir)
+        self.gpg_dir = None
+        self.gpg_key_id = None

--- a/tests/gitfixtures.py
+++ b/tests/gitfixtures.py
@@ -14,8 +14,6 @@ class GitFixtures(Fixtures):
     """
 
     def init(self):
-        self.user_name  = 'test'
-        self.user_email = 'test@test.com'
         self.create_repo(self.repo_path)
         self.wd = self.repo_path
         self.submodules_path = self.container_dir + '/submodules'

--- a/tests/gitfixtures.py
+++ b/tests/gitfixtures.py
@@ -45,7 +45,12 @@ class GitFixtures(Fixtures):
 
     def record_rev(self, wd, rev_num):
         tag = 'tag' + str(rev_num)
-        self.safe_run('tag ' + tag)
+        if self.gpg_dir:
+            args = 'tag -s --local-user=%s -m tag-message %s' \
+                    % (self.gpg_key_id, tag)
+        else:
+            args = 'tag %s' % (tag)
+        self.safe_run(args)
 
         for d in (self.revs, self.timestamps, self.sha1s):
             if wd not in d:
@@ -55,8 +60,9 @@ class GitFixtures(Fixtures):
         self.timestamps[wd][tag] = self.get_metadata('%ct')
         self.sha1s[wd][tag]      = self.get_metadata('%H')
         self.scmlogs.annotate(
-            "Recorded rev %d: id %s, timestamp %s, SHA1 %s in %s" %
-            (rev_num,
+            "Recorded %srev %d: id %s, timestamp %s, SHA1 %s in %s" %
+            ('signed ' if self.gpg_dir else '',
+             rev_num,
              tag,
              self.timestamps[wd][tag],
              self.sha1s[wd][tag],

--- a/tests/svnfixtures.py
+++ b/tests/svnfixtures.py
@@ -20,8 +20,6 @@ class SvnFixtures(Fixtures):
 
     def init(self):
         self.wd_path = self.container_dir + '/wd'
-        self.user_name  = 'test'
-        self.user_email = 'test@test.com'
 
         self.create_repo()
         self.checkout_repo()


### PR DESCRIPTION
This patch-set implements support for git tag GPG signature verification. Although git supports GPG signing of tags and commits, these changes currently only cover use-cases where the user supplied revision directly corresponds to a signed tag.

https://github.com/openSUSE/obs-service-tar_scm/issues/127