### PR TITLE
Allow to extract the version based on git describe --tags without shortening - rebased #112

### DIFF
--- a/tar_scm.py
+++ b/tar_scm.py
@@ -226,27 +226,31 @@ class TarSCM:
             if versionformat is None:
                 versionformat = '%ct.%h'
 
+            abbrev = args['tag_abbrev'] if args['tag_abbrev'] else None
+
+            version = version_iso_cleanup(self.helpers.safe_run(['git', 'log', '-n1', '--date=short',
+                    "--pretty=format:%s" % versionformat], repodir)[1])
+
             if not parent_tag:
-                rc, output = self.helpers.run_cmd(['git', 'describe', '--tags', '--abbrev=0'],
-                                     repodir)
+                rc, output = self.helpers.run_cmd(['git', 'describe', '--tags',
+                                                   '--abbrev={0}'.format(abbrev)], repodir)
                 if rc == 0:
                     # strip to remove newlines
                     parent_tag = output.strip()
-            if re.match('.*@PARENT_TAG@.*', versionformat):
+            if re.match('.*@PARENT_TAG@.*', version):
                 if parent_tag:
-                    versionformat = re.sub('@PARENT_TAG@', parent_tag, versionformat)
+                    versionformat = re.sub('@PARENT_TAG@', parent_tag, version)
                 else:
                     sys.exit("\033[31mNo parent tag present for the checked out "
                              "revision, thus @PARENT_TAG@ cannot be expanded.\033[0m")
 
-            if re.match('.*@TAG_OFFSET@.*', versionformat):
+            if re.match('.*@TAG_OFFSET@.*', version):
                 if parent_tag:
                     rc, output = self.helpers.run_cmd(['git', 'rev-list', '--count',
                                           parent_tag + '..HEAD'], repodir)
                     if not rc:
                         tag_offset = output.strip()
-                        versionformat = re.sub('@TAG_OFFSET@', tag_offset,
-                                               versionformat)
+                        version = re.sub('@TAG_OFFSET@', tag_offset, version)
                     else:
                         sys.exit("\033[31m@TAG_OFFSET@ can not be expanded: " +
                                  output + "\033[0m")
@@ -254,12 +258,10 @@ class TarSCM:
                     sys.exit("\033[31m@TAG_OFFSET@ cannot be expanded, "
                              "as no parent tag was discovered.\033[0m")
 
-            version = self.helpers.safe_run(['git', 'log', '-n1', '--date=short',
-                                "--pretty=format:%s" % versionformat], repodir)[1]
             return version_iso_cleanup(version)
 
         def get_timestamp(self, args, repodir):
-            d = {"parent_tag": None, "versionformat": "%ct"}
+            d = {"parent_tag": None, "versionformat": "%ct", "tag_abbrev": 0}
             timestamp = self.detect_version(d, repodir)
             return int(timestamp)
 
@@ -799,12 +801,12 @@ def cleanup(dirs):
         shutil.rmtree(d)
 
 
-def version_iso_cleanup(version):
+def version_iso_cleanup(version, char=''):
     """Reformat timestamp value."""
     version = re.sub(r'([0-9]{4})-([0-9]{2})-([0-9]{2}) +'
                      r'([0-9]{2})([:]([0-9]{2})([:]([0-9]{2}))?)?'
                      r'( +[-+][0-9]{3,4})', r'\1\2\3T\4\6\8', version)
-    version = re.sub(r'[-:]', '', version)
+    version = re.sub(r'[-:]', char, version)
     return version
 
 
@@ -1109,6 +1111,8 @@ def parse_args():
                              'using this format string.  This parameter is '
                              'used if the \'version\' parameter is not '
                              'specified.')
+    parser.add_argument('--tag-abbrev',
+                        help='Abbreviate @PARENT_TAG@')
     parser.add_argument('--versionprefix',
                         help='Specify a base version as prefix.')
     parser.add_argument('--parent-tag',

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -61,6 +61,13 @@
       For bzr and svn, '%r' is expanded to the revision, and is the default.
     </description>
   </parameter>
+  <parameter name="tag-abbrev">
+    <description>To what length should the output of git describe --tags be abbreviated?
+                 Default: 0
+                 Common other parameter would be 7, which is the 'default'
+                 for "git describe --tags".
+    </description>
+  </param>
   <parameter name="versionprefix">
     <description>Specify a base version as prefix.</description>
   </parameter>

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -100,6 +100,12 @@ class GitTests(GitHgTests, GitSvnTests):
         self.tar_scm_std('--versionformat', "@PARENT_TAG@.@TAG_OFFSET@")
         self.assertTarOnly(self.basename(version=self.rev(2) + ".0"))
 
+    def test_versionformat_parenttag_unshortened(self):
+        # tag-abbrev=7 means using TAG-OFFSET-HASH, EXCEPT when commit == TAG
+        self.tar_scm_std('--versionformat', "@PARENT_TAG@",
+                         '--tag-abbrev=7')
+        self.assertTarOnly(self.basename(version=self.rev(2)))
+
     def _submodule_fixture(self, submod_name):
         fix = self.fixtures
         repo_path = fix.repo_path


### PR DESCRIPTION
(Rebase of #112)

In order to be able to fully automatically have versions extracted from git so far one could rely on something like `@PARENT_TAG@+@TAG_OFFSET@` or `@PARENT_TAG@.%cd` or any other sort of variation.

Those all work reasonably well, but give strange appearance for the case that the git ref being packages is exactly a tag (first would result in +0, second form still gives a commit date)

`@PARENT_TAG@` is implemented by `git describe --abbrev=0`

This change introduces the capability to instruct the tar_scm service if abbrev should be used (=0) and retain the existing `@PARENT_TAG@` behavior or use the new mode (abbrev=7, default for git describe) which in turn results in an automatic version that is 'always usable':

* If the commit is a TAG ref: only shows the TAG name
* If the commit is ahead of a TAG-ref, show TAG-TAG_OFFSET-commithash

Since `-` is not valid in the rpm version field, it is replaced by `.`.
  