### PR TITLE
Fix appimage yml without build section

### DIFF
--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -157,7 +157,7 @@ class tasks():
 
         logging.debug("DST: %s", dstname)
 
-        changes = scm_object.detect_changes()
+        detected_changes = scm_object.detect_changes()
 
         scm_object.prep_tree_for_archive(args.subdir, args.outdir,
                                          dstname=dstname)
@@ -179,7 +179,7 @@ class tasks():
             cli       = args
         )
 
-        if changes:
+        if detected_changes:
             changesauthor = self.changes.get_changesauthor(args)
 
             logging.debug("AUTHOR: %s", changesauthor)
@@ -191,10 +191,10 @@ class tasks():
             for filename in glob.glob('*.changes'):
                 new_changes_file = os.path.join(args.outdir, filename)
                 shutil.copy(filename, new_changes_file)
-                self.changes.write_changes(new_changes_file, changes['lines'],
+                self.changes.write_changes(new_changes_file, detected_changes['lines'],
                                            changesversion, changesauthor)
             self.changes.write_changes_revision(args.url, args.outdir,
-                                                changes['revision'])
+                                                detected_changes['revision'])
 
     def get_version(self, scm_object, args):
         '''

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -140,7 +140,6 @@ class tasks():
         # self.scm_object is need to unlock cache in cleanup
         # if exception occurs
         self.scm_object = scm_object   = scm_class(args, self)
-        helpers      = scm_object.helpers
 
         scm_object.fetch_upstream()
 

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -46,9 +46,14 @@ class tasks():
             self.dataMap = yaml.safe_load(f)
             f.close()
             args.use_obs_scm = True
+            build_scms = ()
+            try:
+                build_scms = self.dataMap['build'].keys()
+            except TypeError:
+                pass
             # run for each scm an own task
             for scm in scms:
-                if scm not in self.dataMap['build'].keys():
+                if scm not in build_scms:
                     continue
                 for url in self.dataMap['build'][scm]:
                     args.url = url

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -36,10 +36,10 @@ class tasks():
         """Cleaning temporary directories."""
         logging.debug("Cleaning: %s", ' '.join(self.cleanup_dirs))
 
-        for d in self.cleanup_dirs:
-            if not os.path.exists(d):
+        for dirname in self.cleanup_dirs:
+            if not os.path.exists(dirname):
                 continue
-            shutil.rmtree(d)
+            shutil.rmtree(dirname)
         self.cleanup_dirs = []
         # Unlock to prevent dead lock in cachedir if exception
         # gets raised
@@ -55,9 +55,9 @@ class tasks():
 
         if args.appimage:
             # we read the SCM config from appimage.yml
-            f = open('appimage.yml')
-            self.data_map = yaml.safe_load(f)
-            f.close()
+            filehandle = open('appimage.yml')
+            self.data_map = yaml.safe_load(filehandle)
+            filehandle.close()
             args.use_obs_scm = True
             build_scms = ()
             try:
@@ -76,9 +76,9 @@ class tasks():
         elif args.snapcraft:
             # we read the SCM config from snapcraft.yaml instead
             # getting it via parameters
-            f = open('snapcraft.yaml')
-            self.data_map = yaml.safe_load(f)
-            f.close()
+            filehandle = open('snapcraft.yaml')
+            self.data_map = yaml.safe_load(filehandle)
+            filehandle.close()
             args.use_obs_scm = True
             # run for each part an own task
             for part in self.data_map['parts'].keys():
@@ -123,8 +123,7 @@ class tasks():
         '''
         do the work for a single task
         '''
-        FORMAT  = "%(message)s"
-        logging.basicConfig(format=FORMAT, stream=sys.stderr,
+        logging.basicConfig(format="%(message)s", stream=sys.stderr,
                             level=logging.INFO)
         if args.verbose:
             logging.getLogger().setLevel(logging.DEBUG)

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -30,6 +30,7 @@ class tasks():
         self.helpers        = helpers()
         self.changes        = changes()
         self.scm_object     = None
+        self.data_map       = None
 
     def cleanup(self):
         """Cleaning temporary directories."""
@@ -55,19 +56,19 @@ class tasks():
         if args.appimage:
             # we read the SCM config from appimage.yml
             f = open('appimage.yml')
-            self.dataMap = yaml.safe_load(f)
+            self.data_map = yaml.safe_load(f)
             f.close()
             args.use_obs_scm = True
             build_scms = ()
             try:
-                build_scms = self.dataMap['build'].keys()
+                build_scms = self.data_map['build'].keys()
             except TypeError:
                 pass
             # run for each scm an own task
             for scm in scms:
                 if scm not in build_scms:
                     continue
-                for url in self.dataMap['build'][scm]:
+                for url in self.data_map['build'][scm]:
                     args.url = url
                     args.scm = scm
                     self.task_list.append(copy.copy(args))
@@ -76,23 +77,23 @@ class tasks():
             # we read the SCM config from snapcraft.yaml instead
             # getting it via parameters
             f = open('snapcraft.yaml')
-            self.dataMap = yaml.safe_load(f)
+            self.data_map = yaml.safe_load(f)
             f.close()
             args.use_obs_scm = True
             # run for each part an own task
-            for part in self.dataMap['parts'].keys():
+            for part in self.data_map['parts'].keys():
                 args.filename = part
-                if 'source-type' not in self.dataMap['parts'][part].keys():
+                if 'source-type' not in self.data_map['parts'][part].keys():
                     continue
-                pep8_1 = self.dataMap['parts'][part]['source-type']
+                pep8_1 = self.data_map['parts'][part]['source-type']
                 if pep8_1 not in scms:
                     continue
                 # avoid conflicts with files
                 args.clone_prefix = "_obs_"
-                args.url = self.dataMap['parts'][part]['source']
-                self.dataMap['parts'][part]['source'] = part
-                args.scm = self.dataMap['parts'][part]['source-type']
-                del self.dataMap['parts'][part]['source-type']
+                args.url = self.data_map['parts'][part]['source']
+                self.data_map['parts'][part]['source'] = part
+                args.scm = self.data_map['parts'][part]['source-type']
+                del self.data_map['parts'][part]['source-type']
                 self.task_list.append(copy.copy(args))
 
         else:
@@ -115,7 +116,7 @@ class tasks():
             # if he is using us in "disabled" mode
             new_file = args.outdir + '/_service:snapcraft:snapcraft.yaml'
             with open(new_file, 'w') as outfile:
-                outfile.write(yaml.dump(self.dataMap,
+                outfile.write(yaml.dump(self.data_map,
                                         default_flow_style=False))
 
     def _process_single_task(self, args):

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -191,7 +191,8 @@ class tasks():
             for filename in glob.glob('*.changes'):
                 new_changes_file = os.path.join(args.outdir, filename)
                 shutil.copy(filename, new_changes_file)
-                self.changes.write_changes(new_changes_file, detected_changes['lines'],
+                self.changes.write_changes(new_changes_file,
+                                           detected_changes['lines'],
                                            changesversion, changesauthor)
             self.changes.write_changes_revision(args.url, args.outdir,
                                                 detected_changes['revision'])

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -1,3 +1,7 @@
+'''
+This module contains the class tasks
+'''
+
 import glob
 import copy
 import atexit
@@ -16,6 +20,10 @@ import yaml
 
 
 class tasks():
+    '''
+    Class to create a task list for formats which can contain more then one scm
+    job like snapcraft or appimage
+    '''
     def __init__(self):
         self.task_list      = []
         self.cleanup_dirs   = []
@@ -38,6 +46,10 @@ class tasks():
             self.scm_object.unlock_cache()
 
     def generate_list(self, args):
+        '''
+        Generate list of scm jobs from appimage.yml, snapcraft.yml or a single
+        job from cli arguments.
+        '''
         scms = ['git', 'tar', 'svn', 'bzr', 'hg']
 
         if args.appimage:
@@ -87,10 +99,16 @@ class tasks():
             self.task_list.append(args)
 
     def process_list(self):
+        '''
+        process tasks from the task_list
+        '''
         for task in self.task_list:
             self._process_single_task(task)
 
     def finalize(self, args):
+        '''
+        final steps after processing task list
+        '''
         if args.snapcraft:
             # write the new snapcraft.yaml file
             # we prefix our own here to be sure to not overwrite user files,
@@ -101,6 +119,9 @@ class tasks():
                                         default_flow_style=False))
 
     def _process_single_task(self, args):
+        '''
+        do the work for a single task
+        '''
         FORMAT  = "%(message)s"
         logging.basicConfig(format=FORMAT, stream=sys.stderr,
                             level=logging.INFO)
@@ -177,6 +198,11 @@ class tasks():
                                                 changes['revision'])
 
     def get_version(self, scm_object, args):
+        '''
+        Generate final version number by detecting version from scm if not
+        given as cli option and applying versionrewrite_pattern and
+        versionprefix if given as cli option
+        '''
         version = args.version
         if version == '_auto_' or args.versionformat:
             version = self.detect_version(scm_object, args)

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -87,6 +87,13 @@ class TasksTestCases(unittest.TestCase):
             self.assertEqual(tasks.task_list[0].__dict__[k], expected[k])
         self.assertEqual(len(tasks.task_list), 1)
 
+    def test_appimage_empty_build_git(self):
+        self.cli.snapcraft = False
+        self.cli.appimage = True
+        self._cd_fixtures_dir()
+        tasks = TarSCM.tasks()
+        tasks.generate_list(self.cli)
+
     def test_generate_task_list_multi_tasks(self):
         expected = {
             'libpipeline': {


### PR DESCRIPTION
This PR contains to major changes:

**1. A bugfix for the appimage service feature**

If you start with appimage.yml without a build section, the appimage service will break with this Exception:

```
Traceback (most recent call last):
  File "/home/frank/prj/obs-service-tar_scm/tests/tasks.py", line 95, in test_appimage_empty_build_git
    tasks.generate_list(self.cli)
  File "/home/frank/prj/obs-service-tar_scm/TarSCM/tasks.py", line 51, in generate_list
    if scm not in self.dataMap['build'].keys():
TypeError: 'NoneType' object has no attribute '__getitem__'
``` 

The first commit includes the bugfix and a testcase with an empty appimage.yml

**2. Various commits for better code quality according to the complaints of pylint**

Those commits are marked with **[lint]**
