### PR TITLE
[tests] new env var TAR_SCM_TC to select test cases

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python2
-#
-# This CLI tool is responsible for running the tests.
-# See TESTING.md for more information.
+'''
+This CLI tool is responsible for running the tests.
+See TESTING.md for more information.
+'''
 
 import os
 import re

--- a/tests/test.py
+++ b/tests/test.py
@@ -71,9 +71,9 @@ def prepare_testsuite(tclasses):
                 if m:
                     # regexp mode
                     regexp = m.group(1)
-                    matcher = lambda t: re.search(regexp, t)
+                    matcher = lambda t, r=regexp: re.search(r, t)
                 else:
-                    matcher = lambda t: t == arg
+                    matcher = lambda t, a=arg: t == a
                 for t in dir(test_class):
                     if not t.startswith('test_'):
                         continue

--- a/tests/test.py
+++ b/tests/test.py
@@ -67,21 +67,21 @@ def prepare_testsuite(tclasses):
         for test_class in tclasses:
             to_run = {}
             for arg in sys.argv[1:]:
-                m = re.match('^/(.+)/$', arg)
-                if m:
+                rmatch = re.match('^/(.+)/$', arg)
+                if rmatch:
                     # regexp mode
-                    regexp = m.group(1)
+                    regexp = rmatch.group(1)
                     matcher = lambda t, r=regexp: re.search(r, t)
                 else:
                     matcher = lambda t, a=arg: t == a
-                for t in dir(test_class):
-                    if not t.startswith('test_'):
+                for tdir in dir(test_class):
+                    if not tdir.startswith('test_'):
                         continue
-                    if matcher(t):
-                        to_run[t] = True
+                    if matcher(tdir):
+                        to_run[tdir] = True
 
-            for t in to_run:
-                testsuite.addTest(test_class(t))
+            for trun in to_run:
+                testsuite.addTest(test_class(trun))
     return testsuite
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -80,7 +80,7 @@ def prepare_testsuite(tclasses):
                     if matcher(t):
                         to_run[t] = True
 
-            for t in to_run.keys():
+            for t in to_run:
                 testsuite.addTest(test_class(t))
     return testsuite
 


### PR DESCRIPTION
Without this patch you have to edit the tests/test.py and comment out
tests you dont want to run in an array called testclasses.

This patch gives you the possibilty to run only selected testclasses
by specifing an environment variable with a comma separated list of
testclasses to run, e.g.

TAR_SCM_TC=UnitTestCases,TasksTestCases PYTHONPATH=. tests/test.py

This is only the first step in direction to fix #146 and #147