### PR TITLE
Fix build error on debian due to missing YAML dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml
 Recommends: mercurial
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.


### PR DESCRIPTION
Fixes build error on debian based systems:

```
[   97s] Running build time source services...
[   97s] Traceback (most recent call last):
[   97s]   File "/usr/lib/obs/service/tar", line 20, in <module>
[   97s]     import TarSCM
[   97s]   File "/usr/lib/obs/service/TarSCM/__init__.py", line 4, in <module>
[   97s]     from TarSCM.tasks      import tasks
[   97s]   File "/usr/lib/obs/service/TarSCM/tasks.py", line 15, in <module>
[   97s]     import yaml
[   97s] ImportError: No module named yaml
```