### PR TITLE
Sort tar file list

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -190,7 +190,7 @@ class tar(BaseArchive):
             # Python 2.6 compatibility
             tar.add(topdir, recursive=False)
         for entry in map(lambda x: os.path.join(topdir, x),
-                         os.listdir(topdir)):
+                         sorted(os.listdir(topdir))):
             try:
                 tar.add(entry, filter=tar_filter)
             except TypeError:


### PR DESCRIPTION
Sort tar file list
to generate tar files in a reproducible way.
    
See https://reproducible-builds.org/ for why this matters.
    
In addition to this change,
to generate completely reproducible tarballs,
the build system also needs
https://github.com/python/cpython/pull/2263