### PR TITLE
finalize method for TarSCM.scm.* classes

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -240,3 +240,6 @@ class scm():
             fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
             self.lock_file.close()
             self.lock_file = None
+
+    def finalize(self):
+        pass

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -27,6 +27,8 @@ class scm():
         self.repocachedir   = None
         self.clone_dir      = None
         self.lock_file      = None
+        self.basename       = None
+        self.repodir        = None
 
         # mandatory arguments
         self.args           = args
@@ -51,8 +53,8 @@ class scm():
 
     def fetch_upstream(self):
         """Fetch sources from repository and checkout given revision."""
-        logging.debug("CACHEDIR: '%s'" % self.repocachedir)
-        logging.debug("SCM: '%s'" % self.scm)
+        logging.debug("CACHEDIR: '%s'", self.repocachedir)
+        logging.debug("SCM: '%s'", self.scm)
         clone_prefix = ""
         if 'clone_prefix' in self.args.__dict__:
             clone_prefix = self.args.__dict__['clone_prefix']
@@ -65,7 +67,7 @@ class scm():
         if not os.path.isdir(self.clone_dir):
             # initial clone
             logging.debug(
-                "[fetch_upstream] Initial checkout/clone to directory: '%s'" %
+                "[fetch_upstream] Initial checkout/clone to directory: '%s'",
                 self.clone_dir
             )
             os.mkdir(self.clone_dir)
@@ -93,19 +95,19 @@ class scm():
 
     def detect_changes(self):
         """Detect changes between revisions."""
-        if (not self.args.changesgenerate):
+        if not self.args.changesgenerate:
             return None
 
-        changes = self.changes.read_changes_revision(self.url, os.getcwd(),
-                                                     self.args.outdir)
+        chgs = self.changes.read_changes_revision(self.url, os.getcwd(),
+                                                  self.args.outdir)
 
-        logging.debug("CHANGES: %s" % repr(changes))
+        logging.debug("CHANGES: %s", repr(chgs))
 
-        changes = self.detect_changes_scm(self.args.subdir, changes)
-        logging.debug("Detected changes:\n%s" % repr(changes))
-        return changes
+        chgs = self.detect_changes_scm(self.args.subdir, chgs)
+        logging.debug("Detected changes:\n%s", repr(chgs))
+        return chgs
 
-    def detect_changes_scm(self, subdir, changes):
+    def detect_changes_scm(self, subdir, chgs):
         sys.exit("changesgenerate not supported with %s SCM" % self.scm)
 
     def get_repocache_hash(self, subdir):
@@ -148,7 +150,7 @@ class scm():
             self.repodir = os.getcwd()
 
         # construct repodir (the parent directory of the checkout)
-        logging.debug("REPOCACHEDIR = '%s'" % self.repocachedir)
+        logging.debug("REPOCACHEDIR = '%s'", self.repocachedir)
         if self.repocachedir:
             if not os.path.isdir(self.repocachedir):
                 os.makedirs(self.repocachedir)
@@ -194,7 +196,7 @@ class scm():
         else:
             self.clone_dir = os.path.abspath(self.repodir)
 
-        logging.debug("[_calc_dir_to_clone_to] CLONE_DIR: %s" % self.clone_dir)
+        logging.debug("[_calc_dir_to_clone_to] CLONE_DIR: %s", self.clone_dir)
 
     def is_sslverify_enabled(self):
         """Returns ``True`` if the ``sslverify`` option has been enabled or
@@ -231,8 +233,8 @@ class scm():
         shutil.copytree(src, dst, symlinks=True)
 
     def lock_cache(self):
-        pd = os.path.join(self.clone_dir, os.pardir, '.lock')
-        self.lock_file = open(os.path.abspath(pd), 'w')
+        pdir = os.path.join(self.clone_dir, os.pardir, '.lock')
+        self.lock_file = open(os.path.abspath(pdir), 'w')
         fcntl.lockf(self.lock_file, fcntl.LOCK_EX)
 
     def unlock_cache(self):

--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -8,7 +8,7 @@ class tar(scm):
         """SCM specific version of fetch_uptream for tar."""
         if self.args.obsinfo is None:
             files = glob.glob('*.obsinfo')
-            if len(files) > 0:
+            if files:
                 # or we refactor and loop about all on future
                 self.args.obsinfo = files[0]
         if self.args.obsinfo is None:
@@ -25,7 +25,7 @@ class tar(scm):
             # not need in case of local osc build
             try:
                 os.rename(self.basename, self.clone_dir)
-            except OSError as e:
+            except OSError:
                 raise SystemExit(
                     "Error while moving from '%s' to '%s')\n"
                     "Current working directory: '%s'" %

--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -14,19 +14,22 @@ class tar(scm):
         if self.args.obsinfo is None:
             raise SystemExit("ERROR: no .obsinfo file found in directory: "
                              "'%s'" % os.getcwd())
-        basename = self.clone_dir = self.read_from_obsinfo(self.args.obsinfo,
-                                                           "name")
+        self.basename = self.clone_dir = self.read_from_obsinfo(
+            self.args.obsinfo,
+            "name"
+        )
         self.clone_dir += "-" + self.read_from_obsinfo(self.args.obsinfo,
                                                        "version")
         if not os.path.exists(self.clone_dir):
+            self.final_rename_needed = 1
             # not need in case of local osc build
             try:
-                os.rename(basename, self.clone_dir)
+                os.rename(self.basename, self.clone_dir)
             except OSError as e:
                 raise SystemExit(
                     "Error while moving from '%s' to '%s')\n"
                     "Current working directory: '%s'" %
-                    (basename, self.clone_dir, os.getcwd())
+                    (self.basename, self.clone_dir, os.getcwd())
                 )
 
     def update_cache(self):
@@ -49,3 +52,8 @@ class tar(scm):
                 return k[1].strip()
             line = infofile.readline()
         return ""
+
+    def finalize(self):
+        """Execute final cleanup of workspace"""
+        if self.final_rename_needed:
+            os.rename(self.clone_dir, self.basename)

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -197,6 +197,8 @@ class tasks():
             self.changes.write_changes_revision(args.url, args.outdir,
                                                 detected_changes['revision'])
 
+        scm_object.finalize()
+
     def get_version(self, scm_object, args):
         '''
         Generate final version number by detecting version from scm if not

--- a/tests/tarfixtures.py
+++ b/tests/tarfixtures.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python2
+
+from tests.fixtures import Fixtures
+
+
+class TarFixtures(Fixtures):
+
+    """Methods to create and populate a tar directory.
+
+    tar tests use this class in order to have something to test against.
+    """
+
+    def init(self):
+        pass
+
+    def run(self, cmd):
+        pass

--- a/tests/tartests.py
+++ b/tests/tartests.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python2
+from __future__ import print_function
+
+import os
+
+from tests.tarfixtures    import TarFixtures
+from tests.testenv        import TestEnvironment
+from tests.testassertions import TestAssertions
+
+
+class TarTestCases(TestEnvironment, TestAssertions):
+    """Unit tests for 'tar'.
+
+    tar-specific tests are in this class.  Other shared tests are
+    included via the class inheritance hierarchy.
+    """
+
+    scm            = 'tar'
+    fixtures_class = TarFixtures
+
+    def test_tar_scm_finalize(self):
+        wdir       = self.pkgdir
+        info = os.path.join(wdir, "test.obsinfo")
+        print("INFOFILE: '%s'" % info)
+        os.chdir(self.pkgdir)
+        obsinfo = open(info, 'w')
+        obsinfo.write(
+            "name: pkgname\n" +
+            "version: 0.1.1\n" +
+            "mtime: 1476683264\n" +
+            "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
+        )
+        obsinfo.close()
+        src_dir = os.path.join(wdir, "pkgname")
+        os.mkdir(src_dir)
+        self.tar_scm_std()
+        self.assertTrue(os.path.isdir(src_dir))

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,6 +19,7 @@ from tests.testenv import TestEnvironment
 from tests.unittestcases import UnitTestCases
 from tests.tasks import TasksTestCases
 from tests.scm import SCMBaseTestCases
+from tests.tartests import TarTestCases
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -36,13 +37,14 @@ def prepare_testclasses():
         # If you are only interested in a particular VCS, you can
         # temporarily comment out any of these or use the env variable
         # TAR_SCM_TC=<comma_separated_list> test.py
-        # TAR_SCM_TC=UnitTestCases,TasksTestCases,SCMBaseTestCases,GitTests,SvnTests,HgTests
+        # export TAR_SCM_TC=UnitTestCases,TasksTestCases,SCMBaseTestCases,GitTests,SvnTests,HgTests,TarTestCases # noqa # pylint: disable=line-too-long
         UnitTestCases,
         TasksTestCases,
         SCMBaseTestCases,
         GitTests,
         SvnTests,
         HgTests,
+        TarTestCases,
         BzrTests
     ]
 


### PR DESCRIPTION
without this patch the scm cache_dir gets renamed from <name> to <name-version>
as described in https://github.com/openSUSE/obs-service-tar_scm/issues/169
    
This patch adds an finalize method to all TarSCM.scm.* classes which simply
"pass"`s. Only TarSCM.scm.tar (used by the "tar" service) has a more specific
 one which moves the directory back to its origin name.
