### PR TITLE
[bugfix] fixes issue #173

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -45,6 +45,7 @@ class Scm():
             self.changes    = Changes()
 
         self._calc_repocachedir()
+        self._final_rename_needed = False
 
     def switch_revision(self):
         '''Switch sources to revision. Dummy implementation for version control

--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -21,7 +21,7 @@ class Tar(Scm):
         self.clone_dir += "-" + self.read_from_obsinfo(self.args.obsinfo,
                                                        "version")
         if not os.path.exists(self.clone_dir):
-            self.final_rename_needed = 1
+            self._final_rename_needed = True
             # not need in case of local osc build
             try:
                 os.rename(self.basename, self.clone_dir)
@@ -55,5 +55,5 @@ class Tar(Scm):
 
     def finalize(self):
         """Execute final cleanup of workspace"""
-        if self.final_rename_needed:
+        if self._final_rename_needed:
             os.rename(self.clone_dir, self.basename)

--- a/tests/tartests.py
+++ b/tests/tartests.py
@@ -6,6 +6,7 @@ import os
 from tests.tarfixtures    import TarFixtures
 from tests.testenv        import TestEnvironment
 from tests.testassertions import TestAssertions
+from TarSCM.scm.tar       import Tar
 
 
 class TarTestCases(TestEnvironment, TestAssertions):
@@ -35,3 +36,19 @@ class TarTestCases(TestEnvironment, TestAssertions):
         os.mkdir(src_dir)
         self.tar_scm_std()
         self.assertTrue(os.path.isdir(src_dir))
+
+    def test_tar_scm_no_finalize(self):  # pylint: disable=no-self-use
+        class FakeCli():  # pylint: disable=no-init,too-few-public-methods
+            def __init__(self):
+                self.url             = ''
+                self.revision        = ''
+                self.changesgenerate = False
+                self.subdir          = ''
+
+        class FakeTasks():  # pylint: disable=no-init,too-few-public-methods
+            pass
+
+        cli                 = FakeCli()
+        tasks               = FakeTasks()
+        tar_obj             = Tar(cli, tasks)
+        tar_obj.finalize()


### PR DESCRIPTION
without this fix, the method finalize in class Tar in module TarSCM.scm.tar
tries to access an nonexistant attribute "final_rename_needed" as documented in #173 . This error
occured not while running with osc - only as source service on the server

this fix adds the attribute "_final_rename_needed" to init and renames
"final_rename_needed" -> "_final_rename_needed" as it is no publice needed
attribute