### PR TITLE
Debian git workflow: add obs_gbp to support git-buildpackage

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -177,6 +177,8 @@ install: dirs tar_scm service compile
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/appimage
 	[ ! -L $(DESTDIR)$(mylibdir)/snapcraft ] || rm $(DESTDIR)$(mylibdir)/snapcraft
 	ln -s tar_scm $(DESTDIR)$(mylibdir)/snapcraft
+	[ ! -L $(DESTDIR)$(mylibdir)/obs_gbp ] || rm $(DESTDIR)$(mylibdir)/obs_gbp
+	ln -s tar_scm $(DESTDIR)$(mylibdir)/obs_gbp
 	find ./TarSCM/ -name '*.py*' -exec install -D -m 644 {} $(DESTDIR)$(mylibdir)/{} \;
 
 .PHONY: dirs
@@ -191,8 +193,9 @@ service: dirs
 	install -m 0644 tar.service $(DESTDIR)$(mylibdir)/
 	install -m 0644 snapcraft.service $(DESTDIR)$(mylibdir)/
 	install -m 0644 appimage.service $(DESTDIR)$(mylibdir)/
-	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/tar_scm.service
-	sed -e '/^===TAR_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/obs_scm.service
+	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===GBP_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/tar_scm.service
+	sed -e '/^===TAR_ONLY/,/^===/d' -e '/^===GBP_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/obs_scm.service
+	sed -e '/^===OBS_ONLY/,/^===/d' -e '/^===TAR_ONLY/,/^===/d' -e '/^===/d' tar_scm.service.in > $(DESTDIR)$(mylibdir)/obs_gbp.service
 
 show-python:
 	@echo "$(PYTHON)"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ a URL, fetch the sources via the SCM from the upstream repository, and
 build a tarball from it.  You can find example `appimage.yml` files
 under the `tests/fixtures/` subdirectory.
 
+### gbp
+The `obs_gbp` service can be used to create Debian source artefacts
+(.dsc, .orig.tar.gz and if non-native .debian.tar.gz or .diff.gz) from
+Git repositories, following the very popular [git-buildpackage workflow.]
+(https://honk.sigxcpu.org/piki/projects/git-buildpackage/)
+Requires git-buildpackage to be installed.
+
 ## Archive Formats
 
 ### tar

--- a/TarSCM/__init__.py
+++ b/TarSCM/__init__.py
@@ -8,6 +8,7 @@ from TarSCM.helpers    import Helpers
 from TarSCM.cli        import Cli
 from TarSCM.archive    import Tar
 from TarSCM.archive    import ObsCpio
+from TarSCM.archive    import Gbp
 from TarSCM.exceptions import OptionsError
 
 
@@ -26,6 +27,9 @@ def run():
 
     if os.path.basename(sys.argv[0]) == "snapcraft":
         _cli.snapcraft = True
+
+    if os.path.basename(sys.argv[0]) == "obs_gbp":
+        _cli.use_obs_gbp = True
 
     task_list = Tasks(_cli)
 

--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -7,6 +7,8 @@ import tarfile
 import shutil
 import glob
 import locale
+import logging
+import tempfile
 
 from TarSCM.helpers import Helpers
 
@@ -229,5 +231,133 @@ class Tar(BaseArchive):
         tar.close()
 
         self.archivefile    = tar.name
+
+        os.chdir(cwd)
+
+
+class Gbp(BaseArchive):
+
+    def create_archive(self, scm_object, **kwargs):
+        """Create Debian source artefacts using git-buildpackage.
+        """
+        args = kwargs['cli']
+        version = kwargs['version']
+
+        (workdir, topdir) = os.path.split(scm_object.clone_dir)
+
+        cwd = os.getcwd()
+        os.chdir(workdir)
+
+        if not args.revision:
+            revision = 'origin/master'
+        else:
+            revision = 'origin/' + args.revision
+
+        command = ['gbp', 'buildpackage', '--git-notify=off',
+                   '--git-force-create', '--git-cleaner="true"']
+
+        # we are not on a proper local branch due to using git-reset but we
+        # anyway use the --git-export option
+        command.extend(['--git-ignore-branch',
+                        "--git-export=%s" % revision])
+
+        # gbp can load submodules without having to run the git command, and
+        # will ignore submodules even if loaded manually unless this option is
+        # passed.
+        if args.submodules:
+            command.extend(['--git-submodules'])
+
+        # create local pristine-tar branch if present
+        ret, output = self.helpers.run_cmd(['git', 'rev-parse', '--verify',
+                                            '--quiet', 'origin/pristine-tar'],
+                                           cwd=scm_object.clone_dir)
+        if not ret:
+            ret, output = self.helpers.run_cmd(['git', 'update-ref',
+                                                'refs/heads/pristine-tar',
+                                                'origin/pristine-tar'],
+                                               cwd=scm_object.clone_dir)
+            if not ret:
+                command.append('--git-pristine-tar')
+            else:
+                command.append('--git-no-pristine-tar')
+        else:
+            command.append('--git-no-pristine-tar')
+
+        # Prevent potentially dangerous arguments from being passed to gbp,
+        # e.g. via cleaner, postexport or other hooks.
+        if args.gbp_build_args:
+            build_args = args.gbp_build_args.split(' ')
+            safe_args = re.compile(
+                '--git-verbose|--git-upstream-tree=.*|--git-no-pristine-tar')
+            p = re.compile('--git-.*|--hook-.*|--.*-hook=.*')
+
+            gbp_args = [arg for arg in build_args if safe_args.match(arg)]
+            dpkg_args = [arg for arg in build_args if not p.match(arg)]
+
+            ignored_args = list(set(build_args) - set(gbp_args + dpkg_args))
+            if ignored_args:
+                logging.info("Ignoring build_args: %s" % ignored_args)
+            command.extend(gbp_args + dpkg_args)
+
+        # Set the version in the changelog. Note that we can't simply use
+        # --source-option=-Dversion=$ver as it will not change the tarball
+        # name, which means dpkg-source -x pkg.dsc will fail as the names
+        # and version will not match
+        cl_path = os.path.join(scm_object.clone_dir, 'debian', 'changelog')
+        if (os.path.isfile(cl_path)
+                and version not in ['', '_none_', '_auto_', None]):
+            # Some characters are legal in Debian's versions but not in a git
+            # tag, so they get substituted
+            version = re.sub(r'_', r'~', version)
+            version = re.sub(r'%', r':', version)
+            with open(cl_path, 'r') as cl:
+                lines = cl.readlines()
+            old_version = re.search(r'.+ \((.+)\) .+', lines[0]).group(1)
+            # non-native packages MUST have a debian revision (-xyz)
+            if (re.search(r'-', old_version) is not None
+                    and re.search(r'-', version)) is None:
+                logging.warning("Package is non-native but requested version"
+                                " %s is native! Ignoring.", version)
+            else:
+                with open(cl_path, 'w+') as cl:
+                    # A valid debian changelog has 'package (version) release'
+                    # as the first line, if it's malformed we don't care as it
+                    # will not even build
+                    logging.debug("Setting version to %s", version)
+                    # gbp by default complains about uncommitted changes
+                    command.append("--git-ignore-new")
+                    lines[0] = re.sub(r'^(.+) \(.+\) (.+)',
+                                      r'\1 (%s) \2' % version, lines[0])
+                    cl.write("".join(lines))
+
+        logging.debug("Running in %s", scm_object.clone_dir)
+
+        self.helpers.safe_run(command, cwd=scm_object.clone_dir)
+
+        # Use dpkg to find out what source artefacts have been built and copy
+        # them back, which allows the script to be future-proof and work with
+        # all present and future package formats
+        sources = self.helpers.safe_run(['dpkg-scansources', workdir],
+                                        cwd=workdir)[1]
+
+        FILES_PATTERN = re.compile(
+            r'^Files:(.*(?:\n .*)+)', flags=re.MULTILINE)
+        for match in FILES_PATTERN.findall(sources):
+            logging.info("Files:")
+            for line in match.strip().split("\n"):
+                fname = line.strip().split(' ')[2]
+                logging.info(" %s", fname)
+                input_file = os.path.join(workdir, fname)
+                output_file = os.path.join(args.outdir, fname)
+
+                if (args.gbp_dch_release_update
+                        and fnmatch.fnmatch(fname, '*.dsc')):
+                    # This tag is used by the build-recipe-dsc to set the OBS
+                    # revision: https://github.com/openSUSE/obs-build/pull/192
+                    logging.debug("Setting OBS-DCH-RELEASE in %s", input_file)
+                    with open(input_file, "a") as dsc_file:
+                        dsc_file.write("OBS-DCH-RELEASE: 1")
+
+                shutil.copy(input_file, output_file)
 
         os.chdir(cwd)

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -144,8 +144,14 @@ class Cli():
         parser.add_argument('--history-depth',
                             help='Obsolete osc service parameter that does '
                                  'nothing')
-        # This option is only used in test cases, in real life you would call
-        # obs_scm instead
+        parser.add_argument('--gbp-build-args', type=str,
+                            default='-nc -uc -us -S',
+                            help='Parameters passed to git-buildpackage')
+        parser.add_argument('--gbp-dch-release-update',
+                            choices=['enable', 'disable'], default='disable',
+                            help='Append OBS release number')
+        # These option is only used in test cases, in real life you would call
+        # obs_scm or obs_gbp instead
         parser.add_argument('--use-obs-scm', default = False,
                             help='use obs scm (obscpio) ')
 
@@ -158,6 +164,8 @@ class Cli():
                                  ' Set locale while service run')
         parser.add_argument('--encoding',
                             help='set encoding while service run')
+        parser.add_argument('--use-obs-gbp', default = False,
+                            help='use obs gbp (requires git-buildpackage) ')
 
         self.verify_args(parser.parse_args(options))
 
@@ -191,6 +199,9 @@ class Cli():
         args.package_meta    = bool(args.package_meta == 'yes')
         args.sslverify       = bool(args.sslverify != 'disable')
         args.use_obs_scm     = bool(args.use_obs_scm)
+        args.use_obs_gbp     = bool(args.use_obs_gbp)
+        args.gbp_dch_release_update = bool(args.gbp_dch_release_update
+                                           != 'disable')
 
         # Allow forcing verbose mode from the environment; this
         # allows debugging when running "osc service disabledrun" etc.

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -251,14 +251,18 @@ class Scm():
             'sslverify' not in self.args.__dict__ or \
             self.args.__dict__['sslverify']
 
-    def version_iso_cleanup(self, version):
+    def version_iso_cleanup(self, version, debian=False):
         """Reformat timestamp value."""
         version = re.sub(r'([0-9]{4})-([0-9]{2})-([0-9]{2}) +'
                          r'([0-9]{2})([:]([0-9]{2})([:]([0-9]{2}))?)?'
                          r'( +[-+][0-9]{3,4})',
                          r'\1\2\3T\4\6\8',
                          version)
-        version = re.sub(r'[-:]', '', version)
+        # avoid removing "-" for Debian packages, which use it to split the
+        # upstream vs downstream version
+        # for RPM it has to be stripped instead, as it's an illegal character
+        if not debian:
+            version = re.sub(r'[-:]', '', version)
         return version
 
     def prepare_working_copy(self):

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -171,6 +171,7 @@ class Git(Scm):
         """
         parent_tag = args['parent_tag']
         versionformat = args['versionformat']
+        debian = args.get('use_obs_gbp', False)
         if versionformat is None:
             versionformat = '%ct.%h'
 
@@ -192,7 +193,7 @@ class Git(Scm):
                                    "--pretty=format:%s" % versionformat],
             self.clone_dir
         )[1]
-        return self.version_iso_cleanup(version)
+        return self.version_iso_cleanup(version, debian)
 
     def _detect_parent_tag(self, args):
         parent_tag = ''

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -201,16 +201,23 @@ class Tasks():
 
         detected_changes = scm_object.detect_changes()
 
-        scm_object.prep_tree_for_archive(args.subdir, args.outdir,
-                                         dstname=dstname)
-        self.cleanup_dirs.append(scm_object.arch_dir)
+        if not args.use_obs_gbp:
+            scm_object.prep_tree_for_archive(args.subdir, args.outdir,
+                                             dstname=dstname)
+            self.cleanup_dirs.append(scm_object.arch_dir)
 
+        # For the GBP service there is no copy in arch_dir, so use clone_dir
+        # which has the same content
+        extract_src = scm_object.arch_dir
         if args.use_obs_scm:
             arch = TarSCM.archive.ObsCpio()
+        elif args.use_obs_gbp:
+            arch = TarSCM.archive.Gbp()
+            extract_src = scm_object.clone_dir
         else:
             arch = TarSCM.archive.Tar()
 
-        arch.extract_from_archive(scm_object.arch_dir, args.extract,
+        arch.extract_from_archive(extract_src, args.extract,
                                   args.outdir)
 
         arch.create_archive(

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
 Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
-Recommends: mercurial
+Recommends: mercurial, git-buildpackage
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -203,6 +203,16 @@ Provides:       obs-service-tar_scm:/usr/lib/obs/service/snapcraft.service
 Experimental snapcraft support: This parses snapcraft.yaml files for SCM
 resources and packages them.
 
+%package -n     obs-service-gbp
+Summary:        Creates Debian source artefacts from a Git repository
+Group:          Development/Tools/Building
+Requires:       git-buildpackage >= 0.6.0
+Requires:       obs-service-obs_scm-common = %version-%release
+Provides:       obs-service-tar_scm:/usr/lib/obs/service/obs_gbp.service
+
+%description -n obs-service-gbp
+Debian git-buildpackage workflow support: uses gbp to create Debian
+source artefacts (.dsc, .origin.tar.gz and .debian.tar.gz if non-native).
 
 %prep
 %setup -q -n obs-service-tar_scm-%version
@@ -252,5 +262,9 @@ make %{use_test}
 %files -n obs-service-snapcraft
 %defattr(-,root,root)
 %{_prefix}/lib/obs/service/snapcraft*
+
+%files -n obs-service-gbp
+%defattr(-,root,root)
+%{_prefix}/lib/obs/service/obs_gbp*
 
 %changelog

--- a/obs_gbp
+++ b/obs_gbp
@@ -1,0 +1,1 @@
+tar_scm.py

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -41,7 +41,10 @@
     <description>Package just a subdirectory.</description>
   </parameter>
   <parameter name="version">
-    <description>Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter.</description>
+    <description>
+      Specify version to be used in tarball.  Defaults to automatically detected value formatted by versionformat parameter (_auto_).
+      Use _none_ to disable version rewriting and use what is defined in the spec or debian/changelog.
+    </description>
   </parameter>
   <parameter name="versionformat">
     <description>

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -11,6 +11,20 @@
   <description>This service uses a SCM client to checkout or update from a given repository.  Supported are svn, git, hg and bzr.</description>
 ===
 
+===GBP_ONLY
+<service name="gbp_scm">
+  <summary>Create Debian source artefacts from SCM repository</summary>
+  <description>This service uses a Git to checkout or update from a given repository and create the Debian source artefacts (.dsc, .origin.tar.gz and .debian.tar.gz if non-native). Can only be used with (and implies) --scm git.</description>
+  <parameter name="gbp-build-args">
+    <description>Parameters passed to git-buildpackage. Default is '-nc -uc -us -S'.</description>
+  </parameter>
+  <parameter name="gbp-dch-release-update">
+    <description>Append OBS release number.  Default is 'disable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
+===
+
   <parameter name="scm">
     <description>Specify SCM to use.</description>
     <allowedvalue>svn</allowedvalue>

--- a/tests/scm.py
+++ b/tests/scm.py
@@ -65,3 +65,23 @@ class SCMBaseTestCases(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as ctx:
             scm_base.prep_tree_for_archive("test3", basedir, "test2")
+
+    def test_version_iso_cleanup(self):
+        # Avoid get_repocache_hash failure in Scm.__init__
+        self.cli.url = ""
+        scm_base = Scm(self.cli, None)
+        self.assertEqual(scm_base.version_iso_cleanup("2.0.1-3", True), "2.0.1-3")
+        self.assertEqual(scm_base.version_iso_cleanup("2.0.1-3", False), "2.0.13")
+        self.assertEqual(scm_base.version_iso_cleanup("2.0.1-3"), "2.0.13")
+        self.assertEqual(scm_base.version_iso_cleanup("1", True), "1")
+        self.assertEqual(scm_base.version_iso_cleanup("1", False), "1")
+        self.assertEqual(scm_base.version_iso_cleanup("1"), "1")
+        self.assertEqual(scm_base.version_iso_cleanup("1.54-1.2", True), "1.54-1.2")
+        self.assertEqual(scm_base.version_iso_cleanup("1.54-1.2", False), "1.541.2")
+        self.assertEqual(scm_base.version_iso_cleanup("1.54-1.2"), "1.541.2")
+        self.assertEqual(scm_base.version_iso_cleanup("2017-01-02 02:23:11 +0100", True),
+                         "20170102T022311")
+        self.assertEqual(scm_base.version_iso_cleanup("2017-01-02 02:23:11 +0100", False),
+                         "20170102T022311")
+        self.assertEqual(scm_base.version_iso_cleanup("2017-01-02 02:23:11 +0100"),
+                         "20170102T022311")


### PR DESCRIPTION
Debian + git developers workflow never include the .dsc file in the
repository, as it is the output of a build, not the input.
This makes it awkward and convoluted to use tar_scm with Debian git
repositories, and just unfeasable with obs_scm.

The most common workflow for Debian developers involves a tool called
git-buildpackage, that can generate the Debian source artefacts
(dsc file, orig.tar.gz and if non-native debian.tar.gz or diff.gz)
from a git repository.

Add a new class in the archive module that calls git-buildpackage as
an alternative to creating a tar archive or an obscpio.

This makes it possible to take advantage of the shared git clones
cache that obs_scm uses, saving a lot of network I/O.

The code is adapted from obs-service-git_buildpackage:
https://github.com/jblunck/obs-service-git_buildpackage

Example of a _service:

```
<services>
  <service name="obs_gbp">
    <param name="url">git://github.com/bluca/czmq.git</param>
    <param name="scm">git</param>
    <param name="revision">obs_gbp</param>
    <param name="versionformat">@PARENT_TAG@+git%cd</param>
    <param name="versionrewrite-pattern">(v|debian/)(.*)</param>
    <param name="versionrewrite-replacement">\2</param>
    <param name="gbp-dch-release-update">enable</param>
    <param name="extract">packaging/redhat/czmq.spec</param>
  </service>
  <service name="set_version" mode="buildtime">
    <param name="file">czmq.spec</param>
  </service>
</services>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensuse/obs-service-tar_scm/179)
<!-- Reviewable:end -->
