### PR TITLE
[dist] fix spec file py_compile for fedora

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -35,6 +35,14 @@ BuildRequires:  bzr
 BuildRequires:  git-core
 BuildRequires:  mercurial
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+%define py_compile(O)  \
+find %1 -name '*.pyc' -exec rm -f {} \\; \
+python -c "import sys, os, compileall; br='%{buildroot}'; compileall.compile_dir(sys.argv[1], ddir=br and (sys.argv[1][len(os.path.abspath(br)):]+'/') or None)" %1 \
+%{-O: \
+find %1 -name '*.pyo' -exec rm -f {} \\; \
+python -O -c "import sys, os, compileall; br='%{buildroot}'; compileall.compile_dir(sys.argv[1], ddir=br and (sys.argv[1][len(os.path.abspath(br)):]+'/') or None)" %1 \
+}
+
 BuildRequires:  PyYAML
 %else
 BuildRequires:  python-PyYAML
@@ -135,7 +143,11 @@ resources and packages them.
 %setup -q -n obs-service-tar_scm-%version
 
 %build
+%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+%py_compile .
+%else
 %py_compile %{buildroot}
+%endif
 
 %install
 make install DESTDIR="%{buildroot}" PREFIX="%{_prefix}" SYSCFG="%{_sysconfdir}"


### PR DESCRIPTION
Without this patch package builds in fedora fails because %py_compile is not a
defined macro in fedora/redhat/centos

[   83s] + cd obs-service-tar_scm-0.8.0.1499787575.2419460
[   83s] + %py_compile /home/abuild/rpmbuild/BUILDROOT/obs-service-tar_scm-0.8.0.1499787575.2419460-189.1.i386
[   83s] /var/tmp/rpm-tmp.5IQzmm: line 29: fg: no job control
[   83s] error: Bad exit status from /var/tmp/rpm-tmp.5IQzmm (%build)

This patch defines a macro %py_compile if building in fedora/redhat/centos.
The macro was copied from the current Tumbleweed macros.