### PR TITLE
change ordering so that latest change is on top

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -234,7 +234,7 @@ class Git(Scm):
 
         logging.debug(dbg_msg)
 
-        lines = self._log_cmd(['--reverse', '--no-merges',
+        lines = self._log_cmd(['--no-merges',
                                '--pretty=format:%s',
                                "%s..%s" % (last_rev, current_rev)],
                               subdir)

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -102,7 +102,7 @@ class Svn(Scm):
         new_lines = []
 
         xml_lines = self.helpers.safe_run(
-            ['svn', 'log', '-r%s:%s' % (revision1, revision2), '--xml'],
+            ['svn', 'log', '-r%s:%s' % (revision2, revision1), '--xml'],
             clone_dir
         )[1]
 

--- a/tests/gitsvntests.py
+++ b/tests/gitsvntests.py
@@ -141,9 +141,9 @@ class GitSvnTests(CommonTests):
             expected_author,
             textwrap.dedent("""\
               - Update to version 0.6.%s:
-                \* 3
-                \* 4
                 \* 5
+                \* 4
+                \* 3
               """) % rev
         )
         self._check_changes(orig_changes, expected_changes_regexp)
@@ -171,9 +171,9 @@ class GitSvnTests(CommonTests):
             expected_author,
             textwrap.dedent("""\
               - Update to version %s:
-                \* 3
-                \* 4
                 \* 5
+                \* 4
+                \* 3
               """) % ver_regex
         )
         self._check_changes(orig_changes, expected_changes_regexp)
@@ -201,9 +201,9 @@ class GitSvnTests(CommonTests):
             expected_author,
             textwrap.dedent("""\
               - Update to version 0.6.%s:
-                \* 6
-                \* 7
                 \* 8
+                \* 7
+                \* 6
               """) % self.changesrevision(rev, abbrev=True)
         )
         self._check_changes(orig_changes, expected_changes_regexp)


### PR DESCRIPTION
This makes diffing of rpm changelogs a lot easier
when different packages pull changes from related git repos

E.g. when upstream does commits
A B C D E
and one package pulls after B and E
and another package pulls after C and E,
both should have at the end a changes file with
E
D
C
B
A

but without this patch, the first one has
C
D
E
A
B

and the 2nd one
D
E
A
B
C

reverse was maybe introduced in commit 88e9d57a by @jblunck 