### PR TITLE
git: Support url change

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -102,6 +102,13 @@ class Git(Scm):
 
     def update_cache(self):
         """Update sources via git."""
+        # Force origin to the wanted URL in case it switched
+        self.helpers.safe_run(
+            ['git', 'config', 'remote.origin.url', self.url],
+            cwd=self.clone_dir,
+            interactive=sys.stdout.isatty()
+        )
+
         self.helpers.safe_run(
             ['git', 'fetch', '--tags'],
             cwd=self.clone_dir,


### PR DESCRIPTION
Reconfigure origin to self.url before fetching changes
so that changing url in the _service file won't end up
with unclear message about missing refs

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>