### PR TITLE
add an option to choose what to replace non iso characters with

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -107,6 +107,10 @@ class Cli():
         parser.add_argument('--history-depth',
                             help='Obsolete osc service parameter that does '
                                  'nothing')
+        parser.add_argument('--iso-cleanup-string',
+                            default='',
+                            help='Characters [-:] are replace by this string.'
+                            ' Defaults to ""')
         # This option is only used in test cases, in real life you would call
         # obs_scm instead
         parser.add_argument('--use-obs-scm', default = False,

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -213,7 +213,7 @@ class Scm():
         version = re.sub(r'([0-9]{4})-([0-9]{2})-([0-9]{2}) +'
                          r'([0-9]{2})([:]([0-9]{2})([:]([0-9]{2}))?)?'
                          r'( +[-+][0-9]{3,4})', r'\1\2\3T\4\6\8', version)
-        version = re.sub(r'[-:]', '', version)
+        version = re.sub(r'[-:]', self.args.iso_cleanup_string, version)
         return version
 
     def prepare_working_copy(self):

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -153,4 +153,7 @@ which get maintained in the SCM. Can be used multiple times.</description>
   <parameter name="changesauthor">
     <description>Specify author of the changes file entry to be written.  Defaults to first email entry in ~/.oscrc, or "opensuse-packaging@opensuse.org" if there is no .oscrc found.</description>
   </parameter>
+  <parameter name="iso-cleanup-string">
+    <description>Characters [-:] are replaced by this string. Defaults to ''.</description>
+  </parameter>
 </service>

--- a/tests/githgtests.py
+++ b/tests/githgtests.py
@@ -56,3 +56,8 @@ class GitHgTests(CommonTests):
         basename = self.basename(version=self.abbrev_sha1s(self.rev(2)))
         th = self.assertTarOnly(basename)
         self.assertTarMemberContains(th, basename + '/a', '2')
+
+    def test_version_iso_cleanup(self):
+        self.tar_scm_std('--versionformat', '3.0-5:256',
+                         '--iso-cleanup-string', '==')
+        self.assertTarOnly(self.basename(version="3.0==5==256"))


### PR DESCRIPTION
Some upstream repos use annoying version format like: 10.2-63.
When running through the service, : and - are deleted which generates
unusable/misleading version strings (10.263).

This patches adds an option (iso-cleanup-string) which allows to choose which charater/string
to use to replace the non iso ones.
Default value is '' which keeps the legacy behaviour.

For example
10.2-63 with iso-cleanup-string='.' will generate 10.2.63

A test is added to check the proper behavior of the option

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>