### PR TITLE
fix for broken links

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -90,7 +90,10 @@ class ObsCpio(BaseArchive):
 
         tstamp = self.helpers.get_timestamp(scm_object, args, topdir)
         for name in sorted(cpiolist):
-            os.utime(name, (tstamp, tstamp))
+            try:
+                os.utime(name, (tstamp, tstamp))
+            except OSError:
+                pass
             proc.stdin.write(name)
             proc.stdin.write("\n")
         proc.stdin.close()

--- a/tests/archiveobscpiotestcases.py
+++ b/tests/archiveobscpiotestcases.py
@@ -128,3 +128,22 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
             files,
             outdir
         )
+
+    def test_obscpio_broken_link(self):
+        tc_name              = inspect.stack()[0][3]
+        cl_name              = self.__class__.__name__
+        scm_object           = Git(self.cli, self.tasks)
+        scm_object.clone_dir = os.path.join(self.fixtures_dir, tc_name, 'repo')
+        scm_object.arch_dir  = os.path.join(self.fixtures_dir, tc_name, 'repo')
+        outdir               = os.path.join(self.tmp_dir, cl_name, tc_name,
+                                            'out')
+        self.cli.outdir      = outdir
+        arch                 = ObsCpio()
+        os.makedirs(outdir)
+        arch.create_archive(
+            scm_object,
+            cli      = self.cli,
+            basename = 'test',
+            dstname  = 'test',
+            version  = '0.1.1'
+        )

--- a/tests/fixtures/ArchiveOBSCpioTestCases/test_obscpio_broken_link/repo/broken_link
+++ b/tests/fixtures/ArchiveOBSCpioTestCases/test_obscpio_broken_link/repo/broken_link
@@ -1,0 +1,1 @@
+non-existant-file


### PR DESCRIPTION
Fixes: #204

This patch catches exceptions raised by os.utime when trying to change
broken (symbolic) links

Without this patch an exception like the following is raise if a source
directory contains a broken link

*********************************************************************************
Traceback (most recent call last):
  File "/usr/lib/obs/service//obs_scm", line 30, in <module>
    main()
  File "/usr/lib/obs/service//obs_scm", line 26, in main
    TarSCM.run()
  File "/usr/lib/obs/service/TarSCM/__init__.py", line 35, in run
    task_list.process_list()
  File "/usr/lib/obs/service/TarSCM/tasks.py", line 109, in process_list
    self.process_single_task(task)
  File "/usr/lib/obs/service/TarSCM/tasks.py", line 192, in process_single_task
    cli       = args
  File "/usr/lib/obs/service/TarSCM/archive.py", line 93, in create_archive
    os.utime(name, (tstamp, tstamp))
OSError: [Errno 2] No such file or directory: 'open-build-service-2.7.51.git20171002.da9742ab0/src/backend/worker/BSConfig.pm'

*********************************************************************************