### PR TITLE
Avoid pointless git checkout on clone

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -258,7 +258,7 @@ class Git(Scm):
         # between multiple services
         org_clone_dir  = self.clone_dir
         self.clone_dir = self.repodir
-        command = ['git', 'clone']
+        command = ['git', 'clone', '--no-checkout']
         use_reference = True
         try:
             if self.args.package_meta:

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -258,7 +258,7 @@ class Git(Scm):
         # between multiple services
         org_clone_dir  = self.clone_dir
         self.clone_dir = self.repodir
-        command = ['git', 'clone', self.repocachedir, self.url, self.clone_dir]
+        command = ['git', 'clone']
         use_reference = True
         try:
             if self.args.package_meta:
@@ -268,10 +268,10 @@ class Git(Scm):
             pass
 
         if use_reference:
-            command = ['git', 'clone', '--reference', org_clone_dir, self.url,
-                       self.clone_dir]
+            command.extend(['--reference', org_clone_dir, self.url])
         else:
-            command = ['git', 'clone', org_clone_dir, self.clone_dir]
+            command.append(org_clone_dir)
+        command.append(self.clone_dir)
         wdir = os.path.abspath(os.path.join(self.clone_dir, os.pardir))
         self.helpers.safe_run(
             command, cwd=wdir, interactive=sys.stdout.isatty())


### PR DESCRIPTION
These 2 commits are extracted from this PR: https://github.com/openSUSE/obs-service-tar_scm/pull/179 given they are independent of the feature being added there, and useful by themselves.

The git clone --no-checkout optimisation can save a lot of I/O and time for large repositories like the kernel - the checkout is pointless as it's immediately followed by another checkout of the requested revision.