### PR TITLE
Only use current dir if it actually looks like git (Fixes #202)

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -147,7 +147,9 @@ class Scm():
         # current work directory to allow the developer to work inside
         # of the git repo and fetch local changes
         if sys.argv[0].endswith("snapcraft") or \
-           (self.args.use_obs_scm and os.getenv('OSC_VERSION')):
+           (self.args.use_obs_scm and
+                os.getenv('OSC_VERSION') and
+                os.path.isdir('.git')):
             self.repodir = os.getcwd()
 
         # construct repodir (the parent directory of the checkout)


### PR DESCRIPTION
It isn't entirely clear what this code is supposed to be doing
but it is definitely wrong to assume that its a git repo
if it doesn't contain .git.