### PR TITLE
RFC: git: use shallow copy to avoid downloading history

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -60,7 +60,7 @@ class Git(Scm):
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for git."""
         # clone if no .git dir exists
-        command = ['git', 'clone', self.url, self.clone_dir]
+        command = ['git', 'clone', '--depth', '1', self.url, self.clone_dir]
         if not self.is_sslverify_enabled():
             command += ['--config', 'http.sslverify=false']
         if self.repocachedir:


### PR DESCRIPTION
I was surprised how slow the download from Git was on my local machine and
realized that the module is attempting to download the whole history just
for creating a tarball from the latest commit.