### PR TITLE
make installation of scm's optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq bzr git mercurial subversion
+  - sudo apt-get install -qq bzr git mercurial subversion tar
 install:
   - pip install -r requirements.txt
   - if [[ ${TRAVIS_PYTHON_VERSION:0:3} == 2.7 ]]; then pip install flake8 pylint; fi

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -7,6 +7,7 @@ import hashlib
 import shutil
 import fcntl
 import time
+import subprocess
 
 from TarSCM.helpers import Helpers
 from TarSCM.changes import Changes
@@ -45,6 +46,13 @@ class Scm():
 
         self._calc_repocachedir()
         self._final_rename_needed = False
+
+    def check_scm(self):
+        '''check version of scm to proof, it is installed and executable'''
+        subprocess.Popen(
+            [self.scm, '--version'],
+            stdout=subprocess.PIPE
+        ).communicate()
 
     def switch_revision(self):
         '''Switch sources to revision. Dummy implementation for version control

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -232,7 +232,7 @@ class Git(Scm):
 
         if last_rev == current_rev:
             logging.debug("No new commits, skipping changes file generation")
-            return
+            return None
 
         dbg_msg = "Generating changes between %s and %s" % (last_rev,
                                                             current_rev)

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -80,7 +80,7 @@ class Svn(Scm):
 
         if last_rev == current_rev:
             logging.debug("No new commits, skipping changes file generation")
-            return
+            return None
 
         if not first_run:
             # Increase last_rev by 1 so we dont get duplication of log messages

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -1,6 +1,7 @@
 '''
 This module contains the class tasks
 '''
+from __future__ import print_function
 
 import glob
 import copy
@@ -10,13 +11,13 @@ import os
 import shutil
 import sys
 import re
+import yaml
 
 import TarSCM.scm
 import TarSCM.archive
 from TarSCM.helpers import Helpers
 from TarSCM.changes import Changes
 from TarSCM.exceptions import OptionsError
-import yaml
 
 
 class Tasks():
@@ -157,6 +158,12 @@ class Tasks():
         # self.scm_object is need to unlock cache in cleanup
         # if exception occurs
         self.scm_object = scm_object   = scm_class(args, self)
+
+        try:
+            scm_object.check_scm()
+        except OSError:
+            print("Please install '%s'" % scm_object.scm)
+            sys.exit(1)
 
         scm_object.fetch_upstream()
 

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -31,9 +31,10 @@ Source:         %{name}-%{version}.tar.gz
 # based distributions
 #Patch0:         0001-Debianization-disable-running-mercurial-tests.patch
 %if %{with obs_scm_testsuite}
-BuildRequires:  bzr
 BuildRequires:  git-core
+BuildRequires:  bzr
 BuildRequires:  mercurial
+BuildRequires:  subversion
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 %define py_compile(O)  \
 find %1 -name '*.pyc' -exec rm -f {} \\; \
@@ -50,15 +51,14 @@ BuildRequires:  python-PyYAML
 BuildRequires:  python-dateutil
 BuildRequires:  python-lxml
 BuildRequires:  python-mock
-BuildRequires:  subversion
 %endif
 BuildRequires:  python >= 2.6
 BuildRequires:  python-unittest2
-Requires:       bzr
 Requires:       git-core
-Requires:       mercurial
+Recommends:     bzr
+Recommends:     mercurial
+Recommends:     subversion
 Requires:       obs-service-obs_scm-common = %version-%release
-Requires:       subversion
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
@@ -99,11 +99,11 @@ Creates a tar archive from local directory
 Summary:        Creates a OBS cpio from a remote SCM resource
 Group:          Development/Tools/Building
 Provides:       obs-service-tar_scm:/usr/lib/obs/service/obs_scm.service
-Requires:       bzr
 Requires:       git-core
-Requires:       mercurial
+Recommends:     bzr
+Recommends:     mercurial
+Recommends:     subversion
 Requires:       obs-service-obs_scm-common = %version-%release
-Requires:       subversion
 
 %description -n obs-service-obs_scm
 Creates a OBS cpio from a remote SCM resource.
@@ -114,11 +114,11 @@ into a tar ball during build time.
 %package -n     obs-service-appimage
 Summary:        Handles source downloads defined in appimage.yml files
 Group:          Development/Tools/Building
-Requires:       bzr
 Requires:       git-core
-Requires:       mercurial
+Recommends:     bzr
+Recommends:     mercurial
+Recommends:     subversion
 Requires:       obs-service-obs_scm-common = %version-%release
-Requires:       subversion
 
 %description -n obs-service-appimage
 Experimental appimage support: This parses appimage.yml files for SCM
@@ -128,11 +128,11 @@ resources and packages them.
 Summary:        Handles source downloads defined in snapcraft.yaml files
 Group:          Development/Tools/Building
 Provides:       obs-service-tar_scm:/usr/lib/obs/service/snapcraft.service
-Requires:       bzr
 Requires:       git-core
-Requires:       mercurial
+Recommends:     bzr
+Recommends:     mercurial
+Recommends:     subversion
 Requires:       obs-service-obs_scm-common = %version-%release
-Requires:       subversion
 
 %description -n obs-service-snapcraft
 Experimental snapcraft support: This parses snapcraft.yaml files for SCM

--- a/tests/scm-wrapper
+++ b/tests/scm-wrapper
@@ -23,4 +23,8 @@ fi
 
 echo "$me $*" >> "$SCM_INVOCATION_LOG"
 
-/usr/bin/$me "$@"
+if [ -x /usr/bin/$me ];then
+  /usr/bin/$me "$@"
+else
+  /bin/$me "$@"
+fi


### PR DESCRIPTION
Starting with SLE15 mercurial will be no longer supported.
Therefore we decided to make installation of scm's optional and
check if the command is installed and executable at runtime.

Three changes are only to make pylint happy again:

import order of "import yaml" in TarSCM.tasks
"return None" in TarSCM.scm.git line 235
"return None" in TarSCM.scm.svn line 83

sorry for mixing into this commit