### PR TITLE
python-unittest2 is only required for the optional make check

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -51,9 +51,9 @@ BuildRequires:  python-PyYAML
 BuildRequires:  python-dateutil
 BuildRequires:  python-lxml
 BuildRequires:  python-mock
+BuildRequires:  python-unittest2
 %endif
 BuildRequires:  python >= 2.6
-BuildRequires:  python-unittest2
 Requires:       git-core
 Recommends:     bzr
 Recommends:     mercurial


### PR DESCRIPTION
Signed-off-by: Olaf Hering <olaf@aepfle.de>