### PR TITLE
Remove clone_dir if clone fails

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -85,8 +85,12 @@ class Git(Scm):
         if self.repocachedir:
             command.insert(2, '--mirror')
         wdir = os.path.abspath(os.path.join(self.repodir, os.pardir))
-        self.helpers.safe_run(
-            command, cwd=wdir, interactive=sys.stdout.isatty())
+        try:
+            self.helpers.safe_run(
+                command, cwd=wdir, interactive=sys.stdout.isatty())
+        except SystemExit as exc:
+            os.removedirs(os.path.join(wdir, self.clone_dir))
+            raise exc
 
         self.fetch_specific_revision()
 


### PR DESCRIPTION
Without this patch, when a clone fails (e.g. because of network problems)
git already created the empty directory. The next time, "git clone" gets
called, it complains, that the directory already exists.

This patch catches the raised exception, deletes the clone_dir and raises
the same exception again. This should prevent from any leftovers while broken
"git clone" run.