### PR TITLE
don't allow DEBUG_TAR_SCM to change behaviour (#240)

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -140,7 +140,8 @@ class Cli():
         args.sslverify       = bool(args.sslverify != 'disable')
         args.use_obs_scm     = bool(args.use_obs_scm)
 
-        # force verbose mode in test-mode
+        # Allow forcing verbose mode from the environment; this
+        # allows debugging when running "osc service disabledrun" etc.
         args.verbose = bool(os.getenv('DEBUG_TAR_SCM'))
 
         for attr in args.__dict__.keys():

--- a/TarSCM/config.py
+++ b/TarSCM/config.py
@@ -34,7 +34,7 @@ class Config():
         self.default_section    = 'tar_scm'
         # We're in test-mode, so don't let any local site-wide
         # or per-user config impact the test suite.
-        if os.getenv('DEBUG_TAR_SCM'):
+        if os.getenv('TAR_SCM_CLEAN_ENV'):
             logging.info("Ignoring config files: test-mode detected")
 
         # fake a section header for configuration files
@@ -80,7 +80,7 @@ class Config():
         value = None
         # We're in test-mode, so don't let any local site-wide
         # or per-user config impact the test suite.
-        if os.getenv('DEBUG_TAR_SCM'):
+        if os.getenv('TAR_SCM_CLEAN_ENV'):
             return value
 
         if section is None and self.fakeheader:

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -44,8 +44,8 @@ class TestEnvironment:
             return
         print("--v-v-- begin setupClass for %s --v-v--" % cls.__name__)
         ScmInvocationLogs.setup_bin_wrapper(cls.scm, cls.tmp_dir)
-        os.putenv('DEBUG_TAR_SCM', 'yes')
-        os.environ['DEBUG_TAR_SCM'] = 'yes'
+        os.putenv('TAR_SCM_CLEAN_ENV', 'yes')
+        os.environ['TAR_SCM_CLEAN_ENV'] = 'yes'
         cls.is_setup = True
         print("--^-^-- end   setupClass for %s --^-^--" % cls.__name__)
         print

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -109,21 +109,21 @@ class UnitTestCases(unittest.TestCase):
         tc_name = inspect.stack()[0][3]
 
         try:
-            tmp = os.environ['DEBUG_TAR_SCM']
+            tmp = os.environ['TAR_SCM_CLEAN_ENV']
         except KeyError:
             tmp = None
 
-        os.environ['DEBUG_TAR_SCM'] = "1"
+        os.environ['TAR_SCM_CLEAN_ENV'] = "1"
 
         files = [[os.path.join(self.fixtures_dir, tc_name, 'test.rc'), True]]
         var = Config(files).get(None, 'var')
         self.assertEqual(var, None)
 
         if tmp:
-            os.environ['DEBUG_TAR_SCM'] = tmp
+            os.environ['TAR_SCM_CLEAN_ENV'] = tmp
         else:
-            os.environ['DEBUG_TAR_SCM'] = ''
-            os.unsetenv('DEBUG_TAR_SCM')
+            os.environ['TAR_SCM_CLEAN_ENV'] = ''
+            os.unsetenv('TAR_SCM_CLEAN_ENV')
 
     def test_changes_get_chga_args(self):
         '''Test if getting changesauthor from cli args works'''


### PR DESCRIPTION
Doing

    export DEBUG_TAR_SCM=yes

before running `osc service disabledrun` is a useful way to debug `tar_scm`, but this was actually changing the behaviour, causing heisenbugs.  So introduce a new `TAR_SCM_CLEAN_ENV` variable which allows the unit test suite to run in a clean environment ignoring any local site-wide or per-user config which could impact the test suite.

Fixes #240.