### PR TITLE
only do git stash save/pop if we have a non-empty working tree (#228)

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -44,7 +44,8 @@ class Git(Scm):
         for rev in revs:
             if self._ref_exists(rev):
                 found_revision = True
-                if os.getenv('OSC_VERSION'):
+                if os.getenv('OSC_VERSION') and \
+                   len(os.listdir(self.clone_dir)) > 1:
                     stash_text = self.helpers.safe_run(
                         self._get_scm_cmd() +
                         ['stash'],

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -1,7 +1,8 @@
-import sys
-import os
 import logging
+import os
 import re
+import sys
+
 from TarSCM.scm.base import Scm
 
 


### PR DESCRIPTION
Thanks to #209 sometimes our working tree will be empty.  In that case don't try to stash a bunch of changes which effectively delete the whole working tree and then re-pop them after switching version.

Fixes #228.