### PR TITLE
Proxy variables not being filled correctly

### DIFF
--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -8,6 +8,8 @@ from TarSCM.scm.base import Scm
 class Bzr(Scm):
     scm = 'bzr'
 
+    Scm.__init__
+
     def _get_scm_cmd(self):
         """Compose a BZR-specific command line using http proxies."""
         # Bazaar honors the http[s]_proxy variables, no action needed

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -9,6 +9,8 @@ from TarSCM.scm.base import Scm
 class Git(Scm):
     scm = 'git'
 
+    Scm.__init__
+
     def _get_scm_cmd(self):
         """Compose a GIT-specific command line using http proxies"""
         # git should honor the http[s]_proxy variables, but we need to

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -10,6 +10,7 @@ from TarSCM.scm.base import Scm
 class Hg(Scm):
     scm = 'hg'
 
+    Scm.__init__
     hgtmpdir = tempfile.mkdtemp()
 
     def _get_scm_cmd(self):

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -14,6 +14,7 @@ from TarSCM.scm.base import Scm
 class Svn(Scm):
     scm = 'svn'
 
+    Scm.__init__
     svntmpdir = tempfile.mkdtemp()
 
     def _get_scm_cmd(self):


### PR DESCRIPTION
Due to the way python deals with subclasses, you need to call the __init__ method from the super class. E.g. it was not calling the __init__ method from the Scm base class. As a consequence, the proxy variables were not being filled up.
