### PR TITLE
Fixes for OBSCPIO metadata packing

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -41,11 +41,12 @@ class ObsCpio(BaseArchive):
     def create_archive(self, scm_object, **kwargs):
         """Create an OBS cpio archive of repodir in destination directory.
         """
-        basename = kwargs['basename']
-        dstname  = kwargs['dstname']
-        version  = kwargs['version']
-        args     = kwargs['cli']
-        commit   = scm_object.get_current_commit()
+        basename         = kwargs['basename']
+        dstname          = kwargs['dstname']
+        version          = kwargs['version']
+        args             = kwargs['cli']
+        commit           = scm_object.get_current_commit()
+        package_metadata = args.package_meta
 
         (workdir, topdir) = os.path.split(scm_object.arch_dir)
         extension = 'obscpio'
@@ -81,11 +82,11 @@ class ObsCpio(BaseArchive):
             files = [f for f in files if re.match(includes, f)]
 
             for name in dirs:
-                if not METADATA_PATTERN.match(name):
+                if not METADATA_PATTERN.match(name) or package_metadata:
                     cpiolist.append(name)
 
             for name in files:
-                if not METADATA_PATTERN.match(name):
+                if not METADATA_PATTERN.match(name) or package_metadata:
                     cpiolist.append(name)
 
         tstamp = self.helpers.get_timestamp(scm_object, args, topdir)

--- a/tar.service
+++ b/tar.service
@@ -16,4 +16,8 @@
   <parameter name="extension">
     <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
   </parameter>
+  <parameter name="package-meta">
+    <description>Package the metadata of SCM to allow the user or OBS to update after un-tar.</description>
+    <allowedvalue>yes</allowedvalue>
+  </parameter>
 </service>


### PR DESCRIPTION
This pull request includes commits regarding the *obs_scm* and *tar* services in order to allow metadata packaging when using the two services together.

The commits have more detailed descriptions of the work done.

Fixes #185.