### PR TITLE
Remove unnecessary dependency on unittest2

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -51,7 +51,6 @@ BuildRequires:  python-PyYAML
 BuildRequires:  python-dateutil
 BuildRequires:  python-lxml
 BuildRequires:  python-mock
-BuildRequires:  python-unittest2
 %endif
 BuildRequires:  python >= 2.6
 Requires:       git-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ mock
 pep8
 python-dateutil
 PyYAML
-unittest2

--- a/tests/archiveobscpiotestcases.py
+++ b/tests/archiveobscpiotestcases.py
@@ -16,11 +16,7 @@ from tests.gitfixtures import GitFixtures
 from tests.scmlogs import ScmInvocationLogs
 
 
-if sys.version_info < (2, 7):
-    # pylint: disable=import-error
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 class ArchiveOBSCpioTestCases(unittest.TestCase):

--- a/tests/scm.py
+++ b/tests/scm.py
@@ -11,10 +11,7 @@ from TarSCM.scm.base import Scm
 
 import TarSCM
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 class SCMBaseTestCases(unittest.TestCase):

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -9,10 +9,7 @@ from mock import MagicMock
 from tar_scm import TarSCM
 from tests.fake_classes import FakeSCM
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 class TasksTestCases(unittest.TestCase):

--- a/tests/test.py
+++ b/tests/test.py
@@ -22,10 +22,7 @@ from tests.scm import SCMBaseTestCases
 from tests.tartests import TarTestCases
 from tests.archiveobscpiotestcases import ArchiveOBSCpioTestCases
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 def str_to_class(string):

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -6,10 +6,7 @@ import re
 import sys
 import tarfile
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 line_start = '(^|\n)'
 

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -16,11 +16,7 @@ from TarSCM.changes import Changes
 from TarSCM.scm.git import Git
 from TarSCM.scm.svn import Svn
 
-if sys.version_info < (2, 7):
-    # pylint: disable=import-error
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 # pylint: disable=duplicate-code


### PR DESCRIPTION
unittest2 is not required since Python 2.6, and we don't support that on
any reasonable platform.