### PR TITLE
changed os.removedirs -> shutil.rmtree

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+import shutil
 
 from TarSCM.scm.base import Scm
 
@@ -155,7 +156,7 @@ class Git(Scm):
             osc_version = os.getenv('OSC_VERSION')
             if (obs_service_daemon and not osc_version):
                 logging.info("Removing corrupt cache!")
-                os.removedirs(self.clone_dir)
+                shutil.rmtree(self.clone_dir)
                 self.fetch_upstream_scm()
             else:
                 logging.info("Please fix corrupt cache directory!")


### PR DESCRIPTION
This patch changes os.removedirs to shutil.rmtree, because
os.removedirs cannot remove directories recursivly.

Without this patch you get an error message like:

OSError: [Errno 39] Directory not empty:

when a cleanup of a corrupt cache dir should be done