### PR TITLE
run download_files in appimage and snapcraft case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ before_install:
   - sudo apt-get install -qq bzr git mercurial subversion tar
 install:
   - pip install -r requirements.txt
+  - mkdir bin
+  - ln -s /usr/bin/true bin/obs-service-download_files # we don't test other services here
+  - export PATH="$PWD/bin:$PATH"
   - if [[ ${TRAVIS_PYTHON_VERSION:0:3} == 2.7 ]]; then pip install flake8 pylint; fi
 script: make check

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -129,6 +129,16 @@ class Tasks():
                 outfile.write(yaml.dump(self.data_map,
                                         default_flow_style=False))
 
+        # execute also download_files for downloading single sources
+        if args.snapcraft or args.appimage:
+            download_files = '/usr/lib/obs/service/download_files'
+            if os.path.exists(download_files):
+                cmd = [download_files, '--outdir', args.outdir]
+                rcode, output = self.helpers.run_cmd(cmd, None)
+
+                if rcode != 0:
+                    raise RuntimeError("download_files has failed:%s" % output)
+
     def process_single_task(self, args):
         '''
         do the work for a single task

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -123,6 +123,7 @@ Requires:       git-core
 Recommends:     bzr
 Recommends:     mercurial
 Recommends:     subversion
+Recommends:     obs-service-download_files
 %endif
 Requires:       obs-service-obs_scm-common = %version-%release
 
@@ -139,6 +140,7 @@ Requires:       git-core
 Recommends:     bzr
 Recommends:     mercurial
 Recommends:     subversion
+Recommends:     obs-service-download_files
 %endif
 Requires:       obs-service-obs_scm-common = %version-%release
 


### PR DESCRIPTION
these build descriptions also specify single file downloads.
Let's just run the existing service for this instead of re-implementing it.