### PR TITLE
Support also SSH urls for Git

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -324,6 +324,6 @@ class Git(Scm):
 
     def check_url(self):
         """check if url is a remote url"""
-        if not re.match("^(https?|ftps?|git)://", self.url):
+        if not re.match("^(https?|ftps?|git|ssh)://", self.url):
             return False
         return True

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -273,6 +273,7 @@ class UnitTestCases(unittest.TestCase):
                     'ftp://example.com',
                     'ftps://example.com',
                     'git://example.com',
+                    'ssh://example.com',
                 ]
             },
             {
@@ -318,6 +319,7 @@ class UnitTestCases(unittest.TestCase):
             'Xbzr://example.com',
             'Xlp://example.com',
             'Xgit://example.com',
+            'Xssh://example.com',
             'Xsvn://example.com',
             '/lala/nana'
         ]


### PR DESCRIPTION
ssh:// URLs are common in private OBS deployments.

Regression got introduced in:
44b3beeaf8663d46467fb3945ddc3d73c65ac452