### PR TITLE
fix regression from 44b3bee

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -324,6 +324,17 @@ class Git(Scm):
 
     def check_url(self):
         """check if url is a remote url"""
-        if not re.match("^(https?|ftps?|git|ssh)://", self.url):
+
+        # no local path allowed
+        if re.match('^file:', self.url):
             return False
-        return True
+
+        if '://' in self.url:
+            return bool(re.match("^(https?|ftps?|git|ssh)://", self.url))
+
+        # e.g. user@host.xy:path/to/repo
+        if re.match('^[^/]+:', self.url):
+            return True
+
+        # Deny by default, might be local path
+        return False

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -274,6 +274,10 @@ class UnitTestCases(unittest.TestCase):
                     'ftps://example.com',
                     'git://example.com',
                     'ssh://example.com',
+                    'example.com:/path/to/remote/repo',
+                    'user@example.com:/path/to/remote/repo',
+                    'user+ext@example.com:/path/to/remote/repo',
+                    'user.name@example.com:/path/to/remote/repo',
                 ]
             },
             {
@@ -321,7 +325,9 @@ class UnitTestCases(unittest.TestCase):
             'Xgit://example.com',
             'Xssh://example.com',
             'Xsvn://example.com',
-            '/lala/nana'
+            '/lala/nana',
+            '/tmp/user@example.com:my/local/path'
+            '/tmp/example.com:my/local/path'
         ]
 
         scms = [


### PR DESCRIPTION
with checking for local repos, usage of ssh compliant url's was no longer
possible.

This fix should reenable those type of urls as described in "man git-clone"

[user@]host.xy:path/to/repo