### PR TITLE
make code python3 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.6"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bzr git mercurial subversion tar
@@ -10,5 +11,5 @@ install:
   - mkdir bin
   - ln -s /usr/bin/true bin/obs-service-download_files # we don't test other services here
   - export PATH="$PWD/bin:$PATH"
-  - if [[ ${TRAVIS_PYTHON_VERSION:0:3} == 2.7 ]]; then pip install flake8 pylint; fi
-script: make check
+  - if [[ ${TRAVIS_PYTHON_VERSION:0:3} == 3.6 ]]; then pip install flake8 pylint; fi
+script: make check${TRAVIS_PYTHON_VERSION:0:1}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,7 +81,13 @@ PYLINT3 = $(call first_in_path_opt,$(ALL_PYLINT3))
 default: check
 
 .PHONY: check check_all
-check: flake8 pylint test # test3
+check: flake8 pylint test test3
+
+.PHONY: check2
+check2: flake8 pylint test
+
+.PHONY: check3
+check3: flake8 pylint test3
 
 .PHONY: list-py-files
 list-py-files:
@@ -94,6 +100,7 @@ flake8:
 	else \
 		echo "Running flake8";\
 		flake8;\
+		echo "Finished flake8";\
 	fi
 
 .PHONY: test

--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -110,8 +110,8 @@ class ObsCpio(BaseArchive):
                 os.utime(name, (tstamp, tstamp))
             except OSError:
                 pass
-            proc.stdin.write(name)
-            proc.stdin.write("\n")
+            proc.stdin.write(name.encode())
+            proc.stdin.write("\n".encode())
         proc.stdin.close()
         ret_code = proc.wait()
         if ret_code != 0:
@@ -157,7 +157,7 @@ class Tar(BaseArchive):
         for i in include:
             # for backward compatibility add a trailing '*' if i isn't a
             # pattern
-            if fnmatch.translate(i) == i + fnmatch.translate(r''):
+            if fnmatch.translate(i) == fnmatch.translate(i + r''):
                 i += r'*'
 
             pat = fnmatch.translate(os.path.join(topdir, i))

--- a/TarSCM/changes.py
+++ b/TarSCM/changes.py
@@ -184,18 +184,19 @@ class Changes():
         mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         os.chmod(tmp_fp.name, mode)
 
-        tmp_fp.write('-' * 67 + '\n')
-        tmp_fp.write("%s - %s\n" % (
+        tmp_fp.write(str('-' * 67 + '\n').encode())
+        tmp_fp.write(str("%s - %s\n" % (
             datetime.datetime.utcnow().strftime('%a %b %d %H:%M:%S UTC %Y'),
-            author))
-        tmp_fp.write('\n')
-        tmp_fp.write("- Update to version %s:\n" % version)
+            author)).encode())
+        tmp_fp.write(b'\n')
+        tmp_fp.write(
+            str("- Update to version %s:\n" % version).encode('utf-8'))
         for line in changes:
-            tmp_fp.write("  * %s\n" % line)
-        tmp_fp.write('\n')
+            tmp_fp.write(str("  * %s\n" % line).encode('utf-8'))
+        tmp_fp.write(str('\n').encode('utf-8'))
 
         old_fp = open(changes_filename, 'r')
-        tmp_fp.write(old_fp.read())
+        tmp_fp.write(str(old_fp.read()).encode('utf-8'))
         old_fp.close()
 
         tmp_fp.close()

--- a/TarSCM/helpers.py
+++ b/TarSCM/helpers.py
@@ -45,10 +45,11 @@ class Helpers():
         else:
             output = proc.communicate()[0]
 
+        output = output.decode()
         if proc.returncode and raisesysexit:
             logging.info("ERROR(%d): %s", proc.returncode, repr(output))
             raise SystemExit(
-                "Command failed(%d): %s" % (proc.returncode, repr(output))
+                "Command failed(%d): '%s'" % (proc.returncode, output)
             )
         else:
             logging.debug("RESULT(%d): %s", proc.returncode, repr(output))

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -154,7 +154,8 @@ class Svn(Scm):
 
     def get_repocache_hash(self, subdir):
         """Calculate hash fingerprint for repository cache."""
-        return hashlib.sha256(self.url + '/' + subdir).hexdigest()
+        return hashlib.sha256(
+            str(self.url + '/' + subdir).encode('utf-8')).hexdigest()
 
     def _get_log(self, clone_dir, revision1, revision2):
         new_lines = []

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -171,7 +171,6 @@ class Tasks():
         # if exception occurs
         self.scm_object = scm_object   = scm_class(args, self)
 
-        # TODO: find a way to mock this function in tests to a stub # noqa: E501 # pylint: disable=fixme
         tmode = bool(os.getenv('TAR_SCM_TESTMODE'))
         if not tmode and not scm_object.check_url():
             sys.exit("--url does not match remote repository")

--- a/tests/gitfixtures.py
+++ b/tests/gitfixtures.py
@@ -42,8 +42,8 @@ class GitFixtures(Fixtures):
         self.safe_run('config user.email ' + self.user_email)
         print("created repo %s" % repo_path)
 
-    def get_metadata(self, formatstr):
-        return self.safe_run('log -n1 --pretty=format:"%s"' % formatstr)[0]
+    def get_metadata(self, fmt):
+        return self.safe_run('log -n1 --pretty=format:"%s"' % fmt)[0].decode()
 
     def record_rev(self, wd, rev_num):
         tag = 'tag' + str(rev_num)

--- a/tests/hgfixtures.py
+++ b/tests/hgfixtures.py
@@ -36,7 +36,7 @@ class HgFixtures(Fixtures):
         print("created repo %s" % self.repo_path)
 
     def get_metadata(self, formatstr):
-        return self.safe_run('log -l1 --template "%s"' % formatstr)[0]
+        return self.safe_run('log -l1 --template "%s"' % formatstr)[0].decode()
 
     def record_rev(self, wd, rev_num):
         tag = str(rev_num - 1)  # hg starts counting changesets at 0

--- a/tests/scm.py
+++ b/tests/scm.py
@@ -54,8 +54,12 @@ class SCMBaseTestCases(unittest.TestCase):
                 "test1"
             )
 
-        self.assertRegexpMatches(ctx.exception.message,
-                                 'No such file or directory')
+        if (hasattr(ctx.exception, 'message')):
+            msg = ctx.exception.message
+        else:
+            msg = ctx.exception
+
+        self.assertRegexpMatches(str(msg), 'No such file or directory')
 
         scm_base.prep_tree_for_archive("test1", basedir, "test2")
 

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -22,32 +22,6 @@ class TestAssertions(unittest.TestCase):
     with operations which the tar_scm unit tests commonly need.
     """
 
-    ######################################################################
-    # backported from 2.7 just in case we're running on an older Python
-    def assertRegexpMatches(self, text, expected_regexp, msg=None):
-        """Fail the test unless the text matches the regular expression."""
-        if isinstance(expected_regexp, basestring):
-            expected_regexp = re.compile(expected_regexp)
-        if not expected_regexp.search(text):
-            msg = msg or "Regexp didn't match"
-            msg = '%s: %r not found in %r' % \
-                  (msg, expected_regexp.pattern, text)
-            raise self.failureException(msg)
-
-    def assertNotRegexpMatches(self, text, unexpected_regexp, msg=None):
-        """Fail the test if the text matches the regular expression."""
-        if isinstance(unexpected_regexp, basestring):
-            unexpected_regexp = re.compile(unexpected_regexp)
-        match = unexpected_regexp.search(text)
-        if match:
-            msg = msg or "Regexp matched"
-            msg = '%s: %r matches %r in %r' % (msg,
-                                               text[match.start():match.end()],
-                                               unexpected_regexp.pattern,
-                                               text)
-            raise self.failureException(msg)
-    ######################################################################
-
     def assertNumDirents(self, dir, expected, msg=''):
         dirents = os.listdir(dir)
         got = len(dirents)
@@ -91,20 +65,20 @@ class TestAssertions(unittest.TestCase):
 
     def assertStandardTar(self, tar, top):
         th, entries = self.assertNumTarEnts(tar, 5)
-        entries.sort(lambda x, y: cmp(x.name, y.name))
+        entries.sort(key=lambda x: x.name)
         self.assertDirents(entries[:3], top)
         self.assertSubdirDirents(entries[3:], top + '/subdir')
         return th
 
     def assertSubdirTar(self, tar, top):
         th, entries = self.assertNumTarEnts(tar, 2)
-        entries.sort(lambda x, y: cmp(x.name, y.name))
+        entries.sort(key=lambda x: x.name)
         self.assertSubdirDirents(entries, top)
         return th
 
     def assertIncludeSubdirTar(self, tar, top):
         th, entries = self.assertNumTarEnts(tar, 3)
-        entries.sort(lambda x, y: cmp(x.name, y.name))
+        entries.sort(key=lambda x: x.name)
         self.assertEqual(entries[0].name, top)
         self.assertSubdirDirents(entries[1:], top + '/subdir')
         return th
@@ -147,7 +121,7 @@ class TestAssertions(unittest.TestCase):
 
     def assertTarMemberContains(self, th, tarmember, contents):
         f = th.extractfile(tarmember)
-        self.assertEqual(contents, "\n".join(f.readlines()))
+        self.assertEqual(contents, f.read().decode())
 
     def assertRanInitialClone(self, logpath, loglines):
         self._find(logpath, loglines,

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -204,7 +204,11 @@ class TestEnvironment:
             ret = 1
             succeeded = False
         except Exception as e:
-            sys.stderr.write(e.message)
+            if (hasattr(e, 'message')):
+                msg = e.message
+            else:
+                msg = e
+            sys.stderr.write(str(msg))
             ret = 1
             succeeded = False
         finally:


### PR DESCRIPTION
The following things have been done to make the code/tests python3 ready:

* fix problems with datatypes (str vs bytes)
* fix changes in exception types
* remove obsolete methods assertRegexpMatches/assertNotRegexpMatches
  from testassertions.py
* fix sort calls

additionally the python3 test has been enabled in 'make check'