### PR TITLE
reuse _service*_servicedata/changes files from previous service runs

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -8,6 +8,7 @@ import shutil
 import fcntl
 import time
 import subprocess
+import glob
 
 from TarSCM.helpers import Helpers
 from TarSCM.changes import Changes
@@ -112,6 +113,13 @@ class Scm():
         """Detect changes between revisions."""
         if not self.args.changesgenerate:
             return None
+
+        old_servicedata = os.path.join(os.getcwd(), '.old', '_servicedata')
+        old_changes_glob = os.path.join(os.getcwd(), '.old', '*.changes')
+        if (os.path.isfile(old_servicedata)):
+            shutil.copy2(old_servicedata, os.getcwd())
+            for filename in glob.glob(old_changes_glob):
+                shutil.copy2(filename, os.getcwd())
 
         chgs = self.changes.read_changes_revision(self.url, os.getcwd(),
                                                   self.args.outdir)


### PR DESCRIPTION
All files starting with _service: are copied into a .old directory
by bs_service.

This commit copies files from a .old directory into cwd if a .old/_servicedata
is found. This is required to reuse _servicedata/*changes files from older runs
if running on server side.

ATTENTION: existing commited files may be overwritten.