### PR TITLE
changes: Copy file content without encoding

### DIFF
--- a/TarSCM/changes.py
+++ b/TarSCM/changes.py
@@ -196,7 +196,7 @@ class Changes():
         tmp_fp.write(str('\n').encode('utf-8'))
 
         old_fp = open(changes_filename, 'r')
-        tmp_fp.write(str(old_fp.read()).encode('utf-8'))
+        tmp_fp.write(old_fp.read())
         old_fp.close()
 
         tmp_fp.close()


### PR DESCRIPTION
Copying binary content of file to an another file descriptor does
not require encoding or decoding, even if there are non-ASCII
characters. In fact, encoding the changes file content caused
errors if it contained non-ASCII characters.

Fixes #264