### PR TITLE
git backend: fix operation when log.showSignature is enabled in config

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -175,11 +175,10 @@ class Git(Scm):
                 parent_tag,
                 versionformat)
 
-        version = self.helpers.safe_run(
-            self._get_scm_cmd() + ['log', '-n1', '--date=short',
-                                   "--pretty=format:%s" % versionformat],
-            self.clone_dir
-        )[1]
+        version = self._log_cmd(
+            ['-n1', '--date=short', "--pretty=format:%s" % versionformat],
+            None
+        )
         return self.version_iso_cleanup(version)
 
     def _detect_parent_tag(self, args):
@@ -247,7 +246,8 @@ class Git(Scm):
 
     def _log_cmd(self, cmd_args, subdir):
         """ Helper function to call 'git log' with args"""
-        cmd = self._get_scm_cmd() + ['log'] + cmd_args
+        cmd = self._get_scm_cmd() + \
+            ['-c', 'log.showSignature=False', 'log'] + cmd_args
         if subdir:
             cmd += ['--', subdir]
         return self.helpers.safe_run(cmd, cwd=self.clone_dir)[1]

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -61,22 +61,28 @@ class UnitTestCases(unittest.TestCase):
         scm     = Git(self.cli, self.tasks)
         # pylint: disable=unused-variable,protected-access
         new_cmd = scm._log_cmd(['-n1'], '')  # noqa
-        safe_run_mock.assert_called_once_with(['git', 'log', '-n1'], cwd=None)
+        safe_run_mock.assert_called_once_with(
+            ['git', '-c', 'log.showSignature=False', 'log', '-n1'],
+            cwd=None)
 
     @patch('TarSCM.Helpers.safe_run')
     def test__git_log_cmd_without_args(self, safe_run_mock):
         scm     = Git(self.cli, self.tasks)
         # pylint: disable=unused-variable,protected-access
         new_cmd = scm._log_cmd([], '')  # noqa
-        safe_run_mock.assert_called_once_with(['git', 'log'], cwd=None)
+        safe_run_mock.assert_called_once_with(
+            ['git', '-c', 'log.showSignature=False', 'log'],
+            cwd=None)
 
     @patch('TarSCM.Helpers.safe_run')
     def test__git_log_cmd_with_subdir(self, safe_run_mock):
         scm     = Git(self.cli, self.tasks)
         # pylint: disable=unused-variable,protected-access
         new_cmd = scm._log_cmd(['-n1'], 'subdir')  # noqa
-        safe_run_mock.assert_called_once_with(['git', 'log', '-n1',
-                                               '--', 'subdir'], cwd=None)
+        safe_run_mock.assert_called_once_with(
+            ['git', '-c', 'log.showSignature=False',
+                'log', '-n1', '--', 'subdir'],
+            cwd=None)
 
     def test_safe_run_exception(self):
         helpers = Helpers()


### PR DESCRIPTION
When running the TarSCM service locally and git configuration item
log.showSignature is enabled, then the git backend fails to work
correctly. For example `git log -n1 --pretty=format:%H -- .` will also
output gpg signature validation information in this case. This messes up
the revision parsing.

To fix this pass `-c log.showSignature=False` to all invocations of `git
log` to disable this feature explicitly. The showSignature feature was
introduced in git 2.10 but passing this command line option should also
work on older versions, since unknown configuration items are silently
ignored by git.

Since `detect_version()` does not use the `_log_cmd()` wrapper, this
invocation needs to be adjusted, too, for making the change in the
central place effective in all code paths.