### PR TITLE
Prefer UTF-8 locale as output format for changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bzr git mercurial subversion tar
+  - sudo locale-gen en_US.UTF-8
 install:
   - pip install -r requirements.txt
   - mkdir bin

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -120,11 +120,11 @@ flake83:
 .PHONY: test
 test:
 	: Running the test suite.  Please be patient - this takes a few minutes ...
-	LANG= LC_TYPE= TAR_SCM_TESTMODE=1 PYTHONPATH=. $(PYTHON) tests/test.py 2>&1 | tee ./test.log
+	LANG=en_US.UTF-8 LC_TYPE=en_US.UTF-8 TAR_SCM_TESTMODE=1 PYTHONPATH=. $(PYTHON) tests/test.py 2>&1 | tee ./test.log
 
 test3:
 	: Running the test suite.  Please be patient - this takes a few minutes ...
-	LANG= LC_TYPE= TAR_SCM_TESTMODE=1 PYTHONPATH=. python3 tests/test.py 2>&1 | tee ./test3.log
+	LANG=en_US.UTF-8 LC_TYPE=en_US.UTF-8 TAR_SCM_TESTMODE=1 PYTHONPATH=. python3 tests/test.py 2>&1 | tee ./test3.log
 
 .PHONY: pylint
 pylint: pylint2 pylinttest2

--- a/KankuFile
+++ b/KankuFile
@@ -47,8 +47,8 @@ jobs:
     options:
       commands:
         - zypper -n in git bzr mercurial subversion make tar
-        - zypper -n in python2-PyYAML python2-python-dateutil python2-mock python2-pylint python2-flake8 python2-chardet
-        - zypper -n in python3-PyYAML python3-python-dateutil python3-mock python3-pylint python3-flake8 python3-chardet
+        - zypper -n in python2-PyYAML python2-python-dateutil python2-mock python2-pylint python2-flake8
+        - zypper -n in python3-PyYAML python3-python-dateutil python3-mock python3-pylint python3-flake8
   -
     use_module: Kanku::Handler::ExecuteCommandViaSSH
     options:

--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -7,7 +7,6 @@ import tarfile
 import shutil
 import glob
 import locale
-import six
 
 from TarSCM.helpers import Helpers
 
@@ -127,7 +126,7 @@ class ObsCpio(BaseArchive):
         metafile.write("mtime: " + str(tstamp) + "\n")
 
         if commit:
-            metafile.write("commit: " + commit.decode() + "\n")
+            metafile.write("commit: " + commit + "\n")
 
         metafile.close()
 
@@ -205,10 +204,7 @@ class Tar(BaseArchive):
         os.chdir(workdir)
         enc = locale.getpreferredencoding()
 
-        if six.PY2:
-            out_file = bytes(os.path.join(outdir, dstname + '.' + extension))
-        else:
-            out_file = os.path.join(outdir, dstname + '.' + extension)
+        out_file = os.path.join(outdir, dstname + '.' + extension)
 
         tar = tarfile.open(out_file, "w", encoding=enc)
 
@@ -217,11 +213,8 @@ class Tar(BaseArchive):
         except TypeError:
             # Python 2.6 compatibility
             tar.add(topdir, recursive=False)
-        ploc = locale.getpreferredencoding()
         for entry in map(lambda x: os.path.join(topdir, x),
                          sorted(os.listdir(topdir))):
-            if six.PY2:
-                entry = entry.encode(ploc)
             try:
                 tar.add(entry, filter=tar_filter)
             except TypeError:

--- a/TarSCM/changes.py
+++ b/TarSCM/changes.py
@@ -5,7 +5,6 @@ import shutil
 import sys
 import tempfile
 import stat
-import chardet
 import io
 import locale
 
@@ -186,15 +185,12 @@ class Changes():
 
         logging.debug("Writing changes file %s", changes_filename)
 
-        enc = locale.getpreferredencoding()
-        for i in changes:
-            if isinstance(i, bytes):
-                tenc = chardet.detect(i)['encoding']
-                if tenc != 'ascii':
-                    enc = tenc
         tmp_fp = tempfile.NamedTemporaryFile(delete=False)
         mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         os.chmod(tmp_fp.name, mode)
+        tmp_filename = tmp_fp.name
+        tmp_fp.close()
+        tmp_fp = io.open(tmp_filename, 'w', encoding="UTF-8")
 
         dtime = datetime.datetime.utcnow().strftime('%a %b %d %H:%M:%S UTC %Y')
 
@@ -203,24 +199,12 @@ class Changes():
         text += '\n'
         text += "- Update to version %s:\n" % version
         for line in changes:
-            if isinstance(line, bytes) and enc:
-                text += "  * %s\n" % line.decode(enc)
-            else:
-                text += "  * %s\n" % line
+            text += "  * %s\n" % line
         text += '\n'
 
-        old_fp = io.open(changes_filename, 'rb')
-        old_text = old_fp.read()
-        char = chardet.detect(old_text)
-        if char['encoding']:
-            old_text = old_text.decode(char['encoding'])
-        text += old_text
+        old_fp = io.open(changes_filename, 'r', encoding='UTF-8')
+        text += old_fp.read()
         old_fp.close()
-        if not enc and char['encoding']:
-            enc = char['encoding']
-
-        if enc:
-            text = text.encode(enc)
 
         tmp_fp.write(text)
         tmp_fp.close()

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -129,7 +129,7 @@ class Cli():
                             help='do not cleanup directories before exiting '
                                  '(Only for debugging)')
 
-        parser.add_argument('--locale',
+        parser.add_argument('--locale', default="en_US.UTF-8",
                             help='set locale while service run')
 
         self.verify_args(parser.parse_args(options))
@@ -173,9 +173,8 @@ class Cli():
             self.__dict__[attr] = args.__dict__[attr]
 
         if args.locale:
-            locale.setlocale(locale.LC_CTYPE, args.locale)
-            os.environ["LC_CTYPE"] = args.locale
             locale.setlocale(locale.LC_ALL, args.locale)
             os.environ["LC_ALL"] = args.locale
+            os.environ["LANG"] = args.locale
 
         return args

--- a/TarSCM/helpers.py
+++ b/TarSCM/helpers.py
@@ -20,12 +20,12 @@ class Helpers():
         SystemExit exception otherwise return a tuple of return code and
         command output.
         """
-        logging.debug("COMMAND: %s", cmd)
+        logging.debug("COMMAND: %s" % cmd)
 
         # Ensure we get predictable results when parsing the output of commands
         # like 'git branch'
         env = os.environ.copy()
-        env['LANG'] = 'C'
+        env['LANG'] = 'en_US.UTF-8'
 
         proc = subprocess.Popen(cmd,
                                 shell=False,
@@ -38,17 +38,20 @@ class Helpers():
             stdout_lines = []
             while proc.poll() is None:
                 for line in proc.stdout:
-                    print(line.rstrip())
-                    stdout_lines.append(line.rstrip())
-            output = b'\n'.join(stdout_lines)
+                    line_str = line.rstrip().decode('UTF-8')
+                    print(line_str)
+                    stdout_lines.append(line_str)
+            output = '\n'.join(stdout_lines)
             output = output
         else:
             output = proc.communicate()[0]
+            if isinstance(output, bytes):
+                output = output.decode('UTF-8')
 
         if proc.returncode and raisesysexit:
             logging.info("ERROR(%d): %s", proc.returncode, repr(output))
             raise SystemExit(
-                "Command failed(%d): '%s'" % (proc.returncode, output.decode())
+                "Command failed(%d): '%s'" % (proc.returncode, output)
             )
         else:
             logging.debug("RESULT(%d): %s", proc.returncode, repr(output))

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -10,7 +10,6 @@ import time
 import subprocess
 import glob
 import locale
-import six
 
 from TarSCM.helpers import Helpers
 from TarSCM.changes import Changes
@@ -258,7 +257,7 @@ class Scm():
                          r'([0-9]{2})([:]([0-9]{2})([:]([0-9]{2}))?)?'
                          r'( +[-+][0-9]{3,4})',
                          r'\1\2\3T\4\6\8',
-                         version.decode())
+                         version)
         version = re.sub(r'[-:]', '', version)
         return version
 
@@ -285,18 +284,8 @@ class Scm():
         if not r_path.startswith(c_dir):
             sys.exit("--subdir %s tries to escape repository." % subdir)
 
-        logging.debug("copying tree: '%s' to '%s'", src, dst)
-        if self.args.locale:
-            ploc = locale.getpreferredencoding()
-            logging.debug("converting src/dst to locale %s", ploc)
-            src = src.encode(ploc)
-            dst = dst.encode(ploc)
-        else:
-            logging.debug("no locale set")
+        logging.debug("copying tree: '%s' to '%s'" % (src, dst))
 
-        if six.PY2:
-            src = bytes(src)
-            dst = bytes(dst)
         shutil.copytree(src, dst, symlinks=True)
 
     def lock_cache(self):

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -46,14 +46,14 @@ class Bzr(Scm):
 
         version = self.helpers.safe_run(self._get_scm_cmd() + ['revno'],
                                         self.clone_dir)[1]
-        return re.sub('%r', version.strip().decode(), versionformat)
+        return re.sub('%r', version.strip(), versionformat)
 
     def get_timestamp(self):
         log = self.helpers.safe_run(
             self._get_scm_cmd() + ['log', '--limit=1', '--log-format=long'],
             self.clone_dir
         )[1]
-        match = re.search(r'timestamp:(.*)', log.decode(), re.MULTILINE)
+        match = re.search(r'timestamp:(.*)', log, re.MULTILINE)
         if not match:
             return 0
         tsm = match.group(1).strip()

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -195,9 +195,6 @@ class Git(Scm):
             # strip to remove newlines
             parent_tag = output.strip()
 
-        if isinstance(parent_tag, bytes):
-            parent_tag = parent_tag.decode()
-
         return parent_tag
 
     def _detect_version_parent_tag(self, parent_tag, versionformat):  # noqa pylint: disable=no-self-use
@@ -224,7 +221,7 @@ class Git(Scm):
             msg.format(out)
             sys.exit(msg)
 
-        tag_offset = out.strip().decode()
+        tag_offset = out.strip()
         versionformat = re.sub('@TAG_OFFSET@', tag_offset,
                                versionformat)
         return versionformat
@@ -261,10 +258,9 @@ class Git(Scm):
         if last_rev is None:
             last_rev = self._log_cmd(
                 ['-n1', '--pretty=format:%H', '--skip=10'], subdir)
-            last_rev = last_rev.decode()
+            last_rev = last_rev
 
         current_rev = self._log_cmd(['-n1', '--pretty=format:%H'], subdir)
-        current_rev = current_rev.decode()
 
         if last_rev == current_rev:
             logging.debug("No new commits, skipping changes file generation")
@@ -283,7 +279,7 @@ class Git(Scm):
                               subdir)
 
         chgs['revision'] = current_rev
-        chgs['lines'] = lines.split(b'\n')
+        chgs['lines'] = lines.split('\n')
         return chgs
 
     def prepare_working_copy(self):

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -119,7 +119,7 @@ class Hg(Scm):
         cmd.extend([
             'log',
             '-l1',
-            "-r%s" % version.strip().decode(),
+            "-r%s" % version.strip(),
             '--template',
             versionformat
         ])

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -133,7 +133,7 @@ class Svn(Scm):
         version = ''
         match = re.search(
             r'Last Changed Rev: (.*)',
-            svn_info.decode(),
+            svn_info,
             re.MULTILINE)
         if match:
             version = match.group(1).strip()
@@ -146,7 +146,7 @@ class Svn(Scm):
 
         match = re.search(
             r'Last Changed Date: (.*)',
-            svn_info.decode(),
+            svn_info,
             re.MULTILINE)
 
         if not match:
@@ -191,8 +191,8 @@ class Svn(Scm):
 
     def get_repocache_hash(self, subdir):
         """Calculate hash fingerprint for repository cache."""
-        string = self.url.encode() + b'/' + subdir.encode()
-        return hashlib.sha256(string).hexdigest()
+        string = self.url + '/' + subdir
+        return hashlib.sha256(string.encode('UTF-8')).hexdigest()
 
     def _get_log(self, clone_dir, revision1, revision2):
         new_lines = []
@@ -203,7 +203,7 @@ class Svn(Scm):
             clone_dir
         )[1]
 
-        lines = re.findall(r"<msg>.*?</msg>", xml_lines.decode(), re.S)
+        lines = re.findall(r"<msg>.*?</msg>", xml_lines, re.S)
 
         for line in lines:
             line = line.replace("<msg>", "").replace("</msg>", "")
@@ -215,13 +215,13 @@ class Svn(Scm):
         cmd = self._get_scm_cmd()
         cmd.extend(['log', '-l%d' % num_commits, '-q', '--incremental'])
         raw = self.helpers.safe_run(cmd, cwd=clone_dir)
-        revisions = raw[1].split(b"\n")
+        revisions = raw[1].split("\n")
         # remove blank entry on end
         revisions.pop()
         # return last entry
         revision = revisions[-1]
         # retrieve the revision number and remove r
-        revision = re.search(r'^r[0-9]*', revision.decode(), re.M)
+        revision = re.search(r'^r[0-9]*', revision, re.M)
         revision = revision.group().replace("r", "")
         return revision
 

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -195,6 +195,8 @@ class Tasks():
         if version and not sys.argv[0].endswith("/tar") \
            and not sys.argv[0].endswith("/snapcraft") \
            and not sys.argv[0].endswith("/appimage"):
+            if isinstance(dstname, bytes):
+                version = version.encode('UTF-8')
             dstname += '-' + version
 
         logging.debug("DST: %s", dstname)

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -55,7 +55,6 @@ BuildRequires:  python-lxml
 BuildRequires:  python-mock
 BuildRequires:  python-unittest2
 BuildRequires:  python-six
-BuildRequires:  python-chardet
 %endif
 BuildRequires:  python >= 2.6
 Requires:       git-core
@@ -79,8 +78,6 @@ It supports downloading from svn, git, hg and bzr repositories.
 Summary:        Common parts of SCM handling services
 Group:          Development/Tools/Building
 Requires:       python-dateutil
-Requires:       python-chardet
-Requires:       python-six
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 Requires:       PyYAML
 %else

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ pep8
 python-dateutil
 PyYAML
 six
-chardet
 pylint
 flake8


### PR DESCRIPTION
The old code had a kinda inverted logic ...

1. we guessed the encoding from the new changes entry
2. encoded the lines with that
3. tried to reencode the old messages also to that encodeing

so if the new messages would match ascii, it would try to reencode
everything as ascii. this can not work.

mls said multiple times that rpm wants to have everything as UTF-8
strings. so why not have everything as UTF-8 as early as possible?

During a discussion with Marcus Huewe, we came to the idea that we could
add a "osc vc --recode" command that would take an existing changes file
and convert each entry to UTF-8. Each entry as the encoding can differ
from entry to entry. In theory even from word to word in an entry. But
lets be optimistic for now.

For the same reason I propose we set the default locale to en_US.UTF-8.
C.UTF-8 is not an official locale, so en_US.UTF-8 seems to be a good
compromise.