### PR TITLE
fix #286: configure a home directory for git

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -11,6 +11,10 @@ class Git(Scm):
     scm = 'git'
 
     def _get_scm_cmd(self):
+        # define a home directory to be able to configure
+        # server-side git credentials and other git settings.
+        os.environ["HOME"] = "/usr/lib/obs"
+
         """Compose a GIT-specific command line using http proxies"""
         # git should honor the http[s]_proxy variables, but we need to
         # guarantee this, the variables do not work every time


### PR DESCRIPTION
Having a home directory allows to store global git settings for the
service if required, for example this allows to store git credentials
if a generally used private git-backend requires a login which the
scm-service should use.
The only other solution would be to store the login credentials in the
_service file which is unacceptable.