### PR TITLE
Boolean logic is hard

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -45,11 +45,11 @@ Source:         %{name}-%{version}.tar.gz
 # based distributions
 #Patch0:         0001-Debianization-disable-running-mercurial-tests.patch
 %if %{with obs_scm_testsuite}
+BuildRequires:  %{locale_package}
 BuildRequires:  bzr
 BuildRequires:  git-core
 BuildRequires:  mercurial
 BuildRequires:  subversion
-BuildRequires:  %{locale_package}
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 %define py_compile(O)  \
 find %1 -name '*.pyc' -exec rm -f {} \\; \
@@ -66,8 +66,8 @@ BuildRequires:  python-PyYAML
 BuildRequires:  python-dateutil
 BuildRequires:  python-lxml
 BuildRequires:  python-mock
-BuildRequires:  python-unittest2
 BuildRequires:  python-six
+BuildRequires:  python-unittest2
 %endif
 BuildRequires:  python >= 2.6
 Requires:       git-core
@@ -89,8 +89,8 @@ It supports downloading from svn, git, hg and bzr repositories.
 %package -n     obs-service-obs_scm-common
 Summary:        Common parts of SCM handling services
 Group:          Development/Tools/Building
-Requires:       python-dateutil
 Requires:       %{locale_package}
+Requires:       python-dateutil
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 Requires:       PyYAML
 %else

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -23,7 +23,11 @@
 %endif
 %endif
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?fedora_version} >= 27 || 0%{?rhel_version} >= 8 || 0%{?centos_version} >= 8
 %define locale_package glibc-langpack-en
+%else
+%define locale_package glibc-common
+%endif
 %endif
 
 %bcond_without obs_scm_testsuite

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -23,7 +23,7 @@
 %endif
 %endif
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
-%if 0%{?fedora_version} >= 27 || 0%{?rhel_version} >= 8 || 0%{?centos_version} >= 8
+%if 0%{?fedora_version} >= 27 || 0%{?rhel_version} >= 800 || 0%{?centos_version} >= 800
 %define locale_package glibc-langpack-en
 %else
 %define locale_package glibc-common


### PR DESCRIPTION
Fix the logic to pick the locale package on Fedora

and RHEL/Centos

the old code in the spec file was

0%{?fedora_version} < 27 || 0%{?rhel_version} < 8 || 0%{?centos_version} < 8

no matter on which distro you build one of those was always false
and that means we never pulled the package for newer distros.

The newer logic fixes this. Also in git this conditional was missing,
while in openSUSE:Tools it was present. This commit also fixes this.

Minimize diff with the version in openSUSE:Tools
The diff is created by the spec format service