### PR TITLE
Git also uses the LANGUAGE variable

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -176,5 +176,6 @@ class Cli():
             locale.setlocale(locale.LC_ALL, args.locale)
             os.environ["LC_ALL"] = args.locale
             os.environ["LANG"] = args.locale
+            os.environ["LANGUAGE"] = args.locale
 
         return args


### PR DESCRIPTION
it seems git ignores the LANG variable if LANGUAGE is also set:

```
LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANGUAGE="de_DE.UTF-8" git status
Auf Branch also-set-language
Änderungen, die nicht zum Commit vorgemerkt sind:
[...]
```

Reported by Marco and Lars.