### PR TITLE
[dist] spec file: python3 only and multidist

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
* changes to remove python2 deps for Leap 15.1/SLE15SP1
* improvements for the following distributions
  * Mageia
  * Mandriva (2011)
  * Scientific Linux