### PR TITLE
fix encoding error for surrogates

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -114,9 +114,10 @@ class ObsCpio(BaseArchive):
             # bytes() break in python2 with a TypeError as it expects only 1
             # arg
             try:
-                proc.stdin.write(bytes(name, 'UTF-8'))
+                proc.stdin.write(name.encode('UTF-8', 'surrogateescape'))
             except TypeError:
                 proc.stdin.write(name)
+
             proc.stdin.write(b"\n")
         proc.stdin.close()
         ret_code = proc.wait()


### PR DESCRIPTION
without this patch, if a filename contains binary char (non-unicode) you
will see errors like this:

--------------------------------------------------------------------------------
  File "/usr/lib/obs/service/TarSCM/archive.py", line 117, in create_archive
    proc.stdin.write(bytes(name, 'UTF-8'))
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 31-36: surrogates not allowed

 #   Failed test 'Checking obs-testpackage'
--------------------------------------------------------------------------------

For further information see:

https://docs.python.org/3/library/codecs.html#error-handlers