### PR TITLE
Override LANGUAGE and LC_ALL to force commands run to use english

### DIFF
--- a/TarSCM/helpers.py
+++ b/TarSCM/helpers.py
@@ -26,6 +26,8 @@ class Helpers():
         # like 'git branch'
         env = os.environ.copy()
         env['LANG'] = 'en_US.UTF-8'
+        env['LANGUAGE'] = 'en'
+        env['LC_ALL'] = 'en_US.UTF-8'
 
         proc = subprocess.Popen(cmd,
                                 shell=False,


### PR DESCRIPTION
Having LANGUAGE=es in the environment was making `osc service disabledrun`
fail because the `No local changes to save\n` text couldn't be parsed by
scm/git.py since git was running in spanish as LANGUAGE has precedence over
LANG, so we now set it too to force using english.

Just to be sure we don't have a similar issue in the future with
different encodings being used because LC_ALL has precedence over LANG,
we also override LC_ALL so we're safe.