### PR TITLE
[dist] Build with python2 for SLE12-SP3

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -22,10 +22,14 @@
 %bcond_with    obs_scm_testsuite
 %endif
 
+%if 0%{?sle_version} && 0%{?sle_version} < 120400
+%bcond_with    python3
+%else
 %if 0%{?suse_version} >= 1315 || 0%{?fedora_version} >= 29
 %bcond_without python3
 %else
 %bcond_with    python3
+%endif
 %endif
 
 # This list probably needs to be extended


### PR DESCRIPTION
In SLE12 SP3 is no dateutil for python3, only for python3. This changed
with SLE12 SP4.

This additional condition ensures that SP3 builds with python2 and everthing
above builds with python3.