### PR TITLE
Don`t break testsuite if cwd contains colons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ python:
   - "3.6"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq bzr git mercurial subversion tar
+  - sudo apt-get install -qq bzr git subversion tar
   - sudo locale-gen en_US.UTF-8
 install:
   - pip install -r requirements.txt
   - mkdir bin
   - ln -s /usr/bin/true bin/obs-service-download_files # we don't test other services here
   - export PATH="$PWD/bin:$PATH"
+  - export TAR_SCM_TC=UnitTestCases,TasksTestCases,SCMBaseTestCases,GitTests,SvnTests,TarTestCases
 script: PV=${TRAVIS_PYTHON_VERSION:0:1};echo $PV;make check$PV

--- a/tests/scmlogs.py
+++ b/tests/scmlogs.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import glob
 import os
+import tempfile
 
 
 class ScmInvocationLogs:
@@ -21,18 +22,17 @@ class ScmInvocationLogs:
     """
 
     @classmethod
-    def setup_bin_wrapper(cls, scm, tmp_dir):
-        cls.wrapper_dir = tmp_dir + '/wrappers'
+    def setup_bin_wrapper(cls, scm, tests_dir):
+        wrapper_dir = tempfile.mkdtemp(dir="/tmp")
 
-        if not os.path.exists(cls.wrapper_dir):
-            os.makedirs(cls.wrapper_dir)
+        wrapper_src = os.path.join(tests_dir, 'scm-wrapper')
+        wrapper_dst = wrapper_dir + '/' + scm
 
-        wrapper = cls.wrapper_dir + '/' + scm
-        if not os.path.exists(wrapper):
-            os.symlink('../../scm-wrapper', wrapper)
+        if not os.path.exists(wrapper_dst):
+            os.symlink(wrapper_src, wrapper_dst)
 
         path = os.getenv('PATH')
-        prepend = cls.wrapper_dir + ':'
+        prepend = wrapper_dir + ':'
 
         if not path.startswith(prepend):
             new_path = prepend + path

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -42,7 +42,7 @@ class TestEnvironment:
         if cls.is_setup:
             return
         print("--v-v-- begin setupClass for %s --v-v--" % cls.__name__)
-        ScmInvocationLogs.setup_bin_wrapper(cls.scm, cls.tmp_dir)
+        ScmInvocationLogs.setup_bin_wrapper(cls.scm, cls.tests_dir)
         os.putenv('TAR_SCM_CLEAN_ENV', 'yes')
         os.environ['TAR_SCM_CLEAN_ENV'] = 'yes'
         cls.is_setup = True


### PR DESCRIPTION
So far we created a directory which contains symbolic links named like
the scm to be tests (e.g. git/svn/bzr/hg etc.) in a subdiretory under
"__file__/tmp/..." which normally is "os.getcwd()/tests/tmp/...". This
path was exported by "os.environ['PATH'] = ....".

This leads to a broken test suite if the current working directory contains
colons, as colon is the separator sign in the PATH env variable.

This patch create a tempdir under "/tmp" which now contains the symbolic links
to the scm-wrapper script to be independent from the current working directory
when executing the test suite.