### PR TITLE
tar_scm.service: fix exclude documentation

### DIFF
--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -118,7 +118,7 @@
     <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
   </parameter>
   <parameter name="exclude">
-    <description>Specify regexp to exclude when creating the tarball.</description>
+    <description>Specify glob pattern to exclude when creating the tarball.</description>
   </parameter>
   <parameter name="include">
     <description>Specify subset of files/subdirectories to pack in the tarball.</description>


### PR DESCRIPTION
It's not a regexp, it's a glob pattern.

Fixes #124.