### PR TITLE
separate language and encoding

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -120,11 +120,11 @@ flake83:
 .PHONY: test
 test:
 	: Running the test suite.  Please be patient - this takes a few minutes ...
-	LANG=en_US.UTF-8 LC_TYPE=en_US.UTF-8 TAR_SCM_TESTMODE=1 PYTHONPATH=. $(PYTHON) tests/test.py 2>&1 | tee ./test.log
+	TAR_SCM_TESTMODE=1 PYTHONPATH=. $(PYTHON) tests/test.py 2>&1 | tee ./test.log
 
 test3:
 	: Running the test suite.  Please be patient - this takes a few minutes ...
-	LANG=en_US.UTF-8 LC_TYPE=en_US.UTF-8 TAR_SCM_TESTMODE=1 PYTHONPATH=. python3 tests/test.py 2>&1 | tee ./test3.log
+	TAR_SCM_TESTMODE=1 PYTHONPATH=. python3 tests/test.py 2>&1 | tee ./test3.log
 
 .PHONY: pylint
 pylint: pylint2 pylinttest2

--- a/TarSCM/helpers.py
+++ b/TarSCM/helpers.py
@@ -22,17 +22,11 @@ class Helpers():
         """
         logging.debug("COMMAND: %s" % cmd)
 
-        # Ensure we get predictable results when parsing the output of commands
-        # like 'git branch'
-        env = os.environ.copy()
-        env['LANG'] = 'en_US.UTF-8'
-
         proc = subprocess.Popen(cmd,
                                 shell=False,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
-                                cwd=cwd,
-                                env=env)
+                                cwd=cwd)
         output = ''
         if interactive:
             stdout_lines = []

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -95,8 +95,7 @@ class Svn(Scm):
         except SystemExit as exc:
             if re.search(ENCODING_RE, exc.code):
                 raise SystemExit(ENCODING_MSG)
-            else:
-                raise exc
+            raise exc
 
     def update_cache(self):
         """Update sources via svn."""

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -149,8 +149,6 @@ class Tasks():
 
         logging.basicConfig(format="%(message)s", stream=sys.stderr,
                             level=logging.INFO)
-        if args.verbose:
-            logging.getLogger().setLevel(logging.DEBUG)
 
         # force cleaning of our workspace on exit
         atexit.register(self.cleanup)

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -154,6 +154,9 @@ which get maintained in the SCM. Can be used multiple times.</description>
     <description>Specify author of the changes file entry to be written.  Defaults to first email entry in ~/.oscrc, or "obs-service-tar-scm@invalid" if there is no .oscrc found.</description>
   </parameter>
   <parameter name="locale">
-    <description>Set locale while execution of service</description>
+    <description>DEPRECATED - Please use "encoding" instead. Set locale while execution of service</description>
+  </parameter>
+  <parameter name="encoding">
+    <description>Set encoding while execution of service</description>
   </parameter>
 </service>

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import subprocess
+import six
 
 
 def mkfreshdir(path):
@@ -22,6 +23,12 @@ def mkfreshdir(path):
 
 
 def run_cmd(cmd):
+    os.putenv('LANG', 'C.utf-8')
+    os.putenv('LC_ALL', 'C.utf-8')
+    os.environ['LANG'] = 'C.utf-8'
+    os.environ['LC_ALL'] = 'C.utf-8'
+    if six.PY3:
+        cmd = cmd.encode('UTF-8')
     proc = subprocess.Popen(cmd, shell=True,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
@@ -60,7 +67,4 @@ def run_hg(repo, args):
 
 
 def run_bzr(repo, args):
-    os.putenv('LANG', 'C')
-    os.environ['LANG'] = 'C'
-
     return run_scm('bzr', repo, args)


### PR DESCRIPTION
according to the following PR's we have problems with the current locale
settings:

https://github.com/openSUSE/obs-build/pull/507
https://github.com/openSUSE/obs-service-tar_scm/pull/317

This PR trys to separate language and encoding settings.
* Determines language to "C" as we need predictable output of the called scm
  commands like git/hg/svn/bzr
* Introduce new option "encoding" to give users the possibility to overwrite
  the encoding which they used in their repo.