### PR TITLE
Mitigate Name clash /on extract fix cache handling

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -128,6 +128,8 @@ class ObsCpio(BaseArchive):
         # write meta data
         metafile = open(os.path.join(args.outdir, basename + '.obsinfo'), "w")
         metafile.write("name: " + basename + "\n")
+        metafile.write(
+            "scmdir: " + os.path.basename(scm_object.clone_dir) + "\n")
         metafile.write("version: " + version + "\n")
         metafile.write("mtime: " + str(tstamp) + "\n")
 

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -136,8 +136,12 @@ class Scm():
 
     def get_repocache_hash(self, subdir):
         """Calculate hash fingerprint for repository cache."""
-        u_url = self.url.encode()
-        return hashlib.sha256(u_url).hexdigest()
+        # tar has no u_url
+        if self.url:
+            u_url = self.url.encode()
+            return hashlib.sha256(u_url).hexdigest()
+        else:
+            return None
 
     def get_current_commit(self):
         return None
@@ -162,7 +166,8 @@ class Scm():
         if repocachedir:
             logging.debug("REPOCACHE: %s", repocachedir)
             self.repohash = self.get_repocache_hash(self.args.subdir)
-            self.repocachedir = os.path.join(repocachedir, self.repohash)
+            if self.repohash:
+                self.repocachedir = os.path.join(repocachedir, self.repohash)
 
     def _calc_proxies(self):
         # check for standard http/https proxy variables

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -230,7 +230,7 @@ class Scm():
         else:
             tempdir = os.getcwd()
 
-        self.repodir = os.path.join(tempdir, self.basename)
+        self.repodir = os.path.join(tempdir, self.basename + '_service')
 
         if self.repocachedir:
             # Update atime and mtime of repocachedir to make it easier

--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -18,10 +18,8 @@ class Tar(Scm):
         if self.args.obsinfo is None:
             raise SystemExit("ERROR: no .obsinfo file found in directory: "
                              "'%s'" % os.getcwd())
-        self.basename = self.clone_dir = self.read_from_obsinfo(
-            self.args.obsinfo,
-            "name"
-        )
+        self.basename  = self.read_from_obsinfo(self.args.obsinfo, "name")
+        self.clone_dir = self.read_from_obsinfo(self.args.obsinfo, "scmdir")
         if "/" in self.clone_dir:
             sys.exit("name in obsinfo contains '/'.")
 
@@ -30,18 +28,18 @@ class Tar(Scm):
         if "/" in version or '..' in version:
             sys.exit("verion in obsinfo contains '/' or '..'.")
 
-        self.clone_dir += "-" + version
+        self.basename += "-" + version
 
         if not os.path.exists(self.clone_dir):
             self._final_rename_needed = True
             # not need in case of local osc build
             try:
-                os.rename(self.basename, self.clone_dir)
+                os.rename(self.clone_dir, self.basename)
             except OSError:
                 raise SystemExit(
                     "Error while moving from '%s' to '%s')\n"
                     "Current working directory: '%s'" %
-                    (self.basename, self.clone_dir, os.getcwd())
+                    (self.clone_dir, self.basename, os.getcwd())
                 )
 
     def update_cache(self):

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -188,7 +188,7 @@ class Tasks():
         if args.filename:
             dstname = basename = args.filename
         else:
-            dstname = basename = os.path.basename(scm_object.clone_dir)
+            dstname = basename = os.path.basename(scm_object.basename)
 
         version = self.get_version()
         changesversion = version

--- a/tests/tartests.py
+++ b/tests/tartests.py
@@ -29,12 +29,13 @@ class TarTestCases(TestEnvironment, TestAssertions):
         obsinfo = open(info, 'w')
         obsinfo.write(
             "name: pkgname\n" +
+            "scmdir: pkgname_service\n" +
             "version: 0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
         )
         obsinfo.close()
-        src_dir = os.path.join(wdir, "pkgname")
+        src_dir = os.path.join(wdir, "pkgname_service")
         os.mkdir(src_dir)
         self.tar_scm_std()
         self.assertTrue(os.path.isdir(src_dir))

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -48,7 +48,7 @@ class UnitTestCases(unittest.TestCase):
         for cdir in clone_dirs:
             scm.url = cdir
             scm._calc_dir_to_clone_to("")  # pylint: disable=protected-access
-            self.assertTrue(scm.clone_dir.endswith('/repo'))
+            self.assertTrue(scm.clone_dir.endswith('/repo_service'))
             self.tasks.cleanup()
 
     @patch('TarSCM.Helpers.safe_run')
@@ -205,6 +205,7 @@ class UnitTestCases(unittest.TestCase):
         f_h = open(info, 'w')
         f_h.write(
             "name: test\n" +
+            "scmdir: test_service\n" +
             "version: 0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
@@ -227,6 +228,7 @@ class UnitTestCases(unittest.TestCase):
         f_h = open(info, 'w')
         f_h.write(
             "name: nonexistantbase\n" +
+            "scmdir: nonexistantbase_service\n" +
             "version: 0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
@@ -344,6 +346,7 @@ class UnitTestCases(unittest.TestCase):
         f_h = open(info, 'w')
         f_h.write(
             "name: test/test\n" +
+            "scmdir: test/test_service\n" +
             "version: 0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
@@ -361,6 +364,7 @@ class UnitTestCases(unittest.TestCase):
         f_h = open(info, 'w')
         f_h.write(
             "name: test\n" +
+            "scmdir: test_service\n" +
             "version: a/0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
@@ -378,6 +382,7 @@ class UnitTestCases(unittest.TestCase):
         f_h = open(info, 'w')
         f_h.write(
             "name: test\n" +
+            "scmdir: test_service\n" +
             "version: ..0.1.1\n" +
             "mtime: 1476683264\n" +
             "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"


### PR DESCRIPTION
These patches resolve two separate issues:

1. The service creates an SCM directory with the same name as the package. If  the package contains a file in its top directory with this name - which is not unlikely - it cannot be extracted.
1. Using a cache directory with service 'tar' fails as the code assumes there is a url which does not exist here.