### PR TITLE
tar_scm.service.in: Add example to match-tag.

### DIFF
--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -79,8 +79,8 @@
   </parameter>
   <parameter name="match-tag">
     <description>
-      With this parameter you can specifiy a glob pattern to filter relevant
-      tags in your project e.g. if you use @PARENT_TAG@
+      With this parameter you can specifiy a glob pattern (e.g. v*) to filter
+      relevant tags in your project e.g. if you use @PARENT_TAG@.
     </description>
   </parameter>
   <parameter name="parent-tag">


### PR DESCRIPTION
This should make it more obvious that `match-tag` uses glob pattern and
not regex syntax like `versionrewrite-pattern`.

It took me a while to realize that `match-tag` doesn't use a regex syntax. I hope that the short example makes it more obvious :)