### PR TITLE
Handle missing build entry in appimage.yml

### DIFF
--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -73,7 +73,7 @@ class Tasks():
             build_scms = ()
             try:
                 build_scms = self.data_map['build'].keys()
-            except TypeError:
+            except (TypeError, KeyError):
                 pass
             # run for each scm an own task
             for scm in scms:

--- a/tests/fixtures/TasksTestCases/test_appimage_empty_build/appimage.yml
+++ b/tests/fixtures/TasksTestCases/test_appimage_empty_build/appimage.yml
@@ -1,0 +1,11 @@
+app: APPIMAGE_NAME
+binpatch: true
+
+ingredients:
+  packages:
+    - RPM_PACKAGE_NAME
+
+script:
+  - cd $BUILD_APPDIR/
+  - cp $BUILD_APPDIR/usr/share/applications/NAME.desktop $BUILD_APPDIR
+  - cp $BUILD_APPDIR/usr/share/pixmaps/NAME.png $BUILD_APPDIR

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -86,6 +86,13 @@ class TasksTestCases(unittest.TestCase):
             self.assertEqual(tasks.task_list[0].__dict__[k], expected[k])
         self.assertEqual(len(tasks.task_list), 1)
 
+    def test_appimage_empty_build(self):
+        self.cli.snapcraft = False
+        self.cli.appimage = True
+        self._cd_fixtures_dir()
+        tasks = TarSCM.Tasks(self.cli)
+        tasks.generate_list()
+
     def test_appimage_empty_build_git(self):
         self.cli.snapcraft = False
         self.cli.appimage = True


### PR DESCRIPTION
Appimages can be created from an "ingredients" entry, when they are not built from source.

[Documentation](https://docs.appimage.org/packaging-guide/obs.html#appimage-yml-file) describes the simplest example as:

```yml
app: APPIMAGE_NAME
binpatch: true

ingredients:
  packages:
    - RPM_PACKAGE_NAME

script:
  - cd $BUILD_APPDIR/
  - cp $BUILD_APPDIR/usr/share/applications/NAME.desktop $BUILD_APPDIR
  - cp $BUILD_APPDIR/usr/share/pixmaps/NAME.png $BUILD_APPDIR
```

In that case, there is no `build` entry. The error in that case is:

```
Running /usr/lib/obs/service//appimage --outdir /var/cache/obs/3oukFs09Woww/out
+ echo Running /usr/lib/obs/service//appimage --outdir /var/cache/obs/3oukFs09Woww/out
+ export HOME=/var/cache/obs/3oukFs09Woww/home
+ HOME=/var/cache/obs/3oukFs09Woww/home
+ /usr/lib/obs/service//appimage --outdir /var/cache/obs/3oukFs09Woww/out
Traceback (most recent call last):
  File "/usr/lib/obs/service//appimage", line 30, in <module>
    main()
  File "/usr/lib/obs/service//appimage", line 26, in main
    TarSCM.run()
  File "/usr/lib/obs/service/TarSCM/__init__.py", line 32, in run
    task_list.generate_list()
  File "/usr/lib/obs/service/TarSCM/tasks.py", line 75, in generate_list
    build_scms = self.data_map['build'].keys()
KeyError: 'build'
```

Which is a `KeyError`, which this patch proposes to handle.

*WARNING*: I did not test this patch, but if you tell me how. I will.