### PR TITLE
update_cache in git now does merge

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -138,6 +138,11 @@ class Git(Scm):
                 cwd=self.clone_dir,
                 interactive=sys.stdout.isatty()
             )
+            self.helpers.safe_run(
+                self._get_scm_cmd() + ['merge'],
+                cwd=self.clone_dir,
+                interactive=sys.stdout.isatty()
+            )
 
             self.fetch_specific_revision()
         except SystemExit as exc:


### PR DESCRIPTION
With 3e17a9a4 we changed the order of the precedence between local and remote
branch, which resulted in problems that the cache directory never gets updated
once it was checked out.

This patch ensures that changes from the origin branch now get merged into the
local branch.