### PR TITLE
fix decoding for locale -a containg non-ASCII

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -23,13 +23,13 @@ def check_locale(loc):
     aloc_tmp = subprocess.check_output(['locale', '-a'])
     aloc = dict()
 
-    for tloc in aloc_tmp.decode().split('\n'):
+    for tloc in aloc_tmp.split(b'\n'):
         aloc[tloc] = 1
 
     for tloc in loc:
         logging.debug("Checking .... %s", tloc)
         try:
-            if aloc[tloc]:
+            if aloc[tloc.encode()]:
                 return tloc
         except KeyError:
             pass


### PR DESCRIPTION
On RHEL7 locale -a contains bokmål wich cannot be
decoded.

So we just use the bytes-like object and split usind b'\n'

And just encodde tloc for use as an index of aloc

fixes https://github.com/openSUSE/obs-service-tar_scm/issues/326