### PR TITLE
Re-enable compatibility with Python 2.6

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -20,7 +20,12 @@ def contains_dotdot(files):
 
 
 def check_locale(loc):
-    aloc_tmp = subprocess.check_output(['locale', '-a'])
+    try:
+        aloc_tmp = subprocess.check_output(['locale', '-a'])
+    except AttributeError:
+        aloc_tmp, _ = subprocess.Popen(['locale', '-a'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT).communicate()
     aloc = dict()
 
     for tloc in aloc_tmp.decode().split('\n'):


### PR DESCRIPTION
Required for CentOS6, RHEL6, SLES ES6...

Fixes #334 (however to get CentOS6 and CentOS7 working again, #333 or an alternative needs to be accepted).

Both PRs as patches can be seen building at https://build.opensuse.org/package/show/systemsmanagement:Uyuni:Master:Temp/obs-service-tar_scm and being used and working at https://build.opensuse.org/package/show/systemsmanagement:Uyuni:Master:CentOS6-Uyuni-Client-Tools:Build-Dependencies/python-gzipstream