### PR TITLE
Fix --mirror argument position for git clone

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -81,7 +81,7 @@ class Git(Scm):
         if not self.is_sslverify_enabled():
             command += ['--config', 'http.sslverify=false']
         if self.repocachedir:
-            command.insert(2, '--mirror')
+            command.insert(command.index('clone') + 1, '--mirror')
         wdir = os.path.abspath(os.path.join(self.repodir, os.pardir))
         try:
             self.helpers.safe_run(


### PR DESCRIPTION
If either http_proxy or https_proxy environment variable is set and
repo cache directory is utilized, the --mirror argument is inserted
into the wrong place when performing git clone. Consequently, user
will see this error.

'error: key does not contain a section: --mirror'

This patch make sure the '--mirror' argument is insert right after
the clone command instead of indiscriminately into position 2 of the
command list.