### PR TITLE
Add git-lfs support

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -115,6 +115,12 @@ class Cli():
                                  'from SCM commit log since a given parent '
                                  'revision (see changesrevision). Use '
                                  '\'master\' to fetch the latest master.')
+        parser.add_argument('--lfs',
+                            choices=['enable', 'disable'],
+                            default='disable',
+                            help='Whether or not to include git lfs blobs '
+                                 'from SCM commit log since a given parent '
+                                 'revision (see changesrevision).')
         parser.add_argument('--sslverify', choices=['enable', 'disable'],
                             default='enable',
                             help='Whether or not to check server certificate '

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -103,10 +103,15 @@ class Scm():
         # submodules since they depend on the actual version of the selected
         # revision
         self.fetch_submodules()
+        self.fetch_lfs()
 
         self.unlock_cache()
 
     def fetch_submodules(self):
+        """NOOP in other scm's than git"""
+        pass
+
+    def fetch_lfs(self):
         """NOOP in other scm's than git"""
         pass
 

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -103,7 +103,11 @@ class Scm():
         # submodules since they depend on the actual version of the selected
         # revision
         self.fetch_submodules()
-        self.fetch_lfs()
+
+        # obs_scm specific: do not allow running git-lfs to prevent storage
+        #  duplication with tar_scm
+        if self.args.use_obs_scm:
+            self.fetch_lfs()
 
         self.unlock_cache()
 

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -117,6 +117,19 @@ class Git(Scm):
                 cwd=self.clone_dir
             )
 
+    def fetch_lfs(self):
+        """Initialize git lfs objects."""
+        argsd = self.args.__dict__
+        if ('lfs' in argsd and argsd['lfs'] == 'enable'):
+            self.helpers.safe_run(
+                self._get_scm_cmd() + ['lfs', 'fetch'],
+                cwd=self.clone_dir
+            )
+            self.helpers.safe_run(
+                self._get_scm_cmd() + ['lfs', 'checkout'],
+                cwd=self.clone_dir
+            )
+
     def update_cache(self):
         """Update sources via git."""
         # Force origin to the wanted URL in case it switched

--- a/appimage.service
+++ b/appimage.service
@@ -7,6 +7,11 @@
     <allowedvalue>master</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+  <parameter name="lfs">
+    <description>Specify whether to include git lfs blobs.  Default is 'disable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
   <parameter name="sslverify">
     <description>Specify Whether or not to check server certificate against installed CAs.  Default is 'enable'.</description>
     <allowedvalue>enable</allowedvalue>

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all, git-lfs
 Recommends: mercurial
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,8 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all, git-lfs
-Recommends: mercurial
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
+Recommends: mercurial, git-buildpackage, git-lfs
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.

--- a/snapcraft.service
+++ b/snapcraft.service
@@ -7,6 +7,11 @@
     <allowedvalue>master</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+  <parameter name="lfs">
+    <description>Specify whether to include git lfs blobs.  Default is 'disable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
   <parameter name="sslverify">
     <description>Specify Whether or not to check server certificate against installed CAs.  Default is 'enable'.</description>
     <allowedvalue>enable</allowedvalue>

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -140,11 +140,13 @@ which get maintained in the SCM. Can be used multiple times.</description>
     <allowedvalue>master</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+===OBS_ONLY
   <parameter name="lfs">
     <description>Specify whether to include git-lfs blobs.  Default is 'disable'.</description>
     <allowedvalue>enable</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+===
   <parameter name="sslverify">
     <description>Specify Whether or not to check server certificate against installed CAs.  Default is 'enable'.</description>
     <allowedvalue>enable</allowedvalue>

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -140,6 +140,11 @@ which get maintained in the SCM. Can be used multiple times.</description>
     <allowedvalue>master</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>
+  <parameter name="lfs">
+    <description>Specify whether to include git-lfs blobs.  Default is 'disable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
   <parameter name="sslverify">
     <description>Specify Whether or not to check server certificate against installed CAs.  Default is 'enable'.</description>
     <allowedvalue>enable</allowedvalue>


### PR DESCRIPTION
[git-lfs](https://git-lfs.github.com/) is an "easy" to store large files in git(hub) repository.
This PR add support for it the same way it's done with git submodules.
```
<services>
  <service name="obs_scm">
    <param name="url">https://github.com/openSUSE/obs-service-tar_scm.git</param>
    <param name="scm">git</param>
    <param name="lfs">enable</param>
    <param name="exclude">.git</param>
    <param name="revision">master</param>
    <param name="versionformat">@PARENT_TAG@.@TAG_OFFSET@</param>
  </service>
```