### PR TITLE
call git stash with LANG=C

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -45,6 +45,12 @@ class Git(Scm):
                 found_revision = True
                 if os.getenv('OSC_VERSION') and \
                    len(os.listdir(self.clone_dir)) > 1:
+                    # Ensure that the call of "git stash" is done with
+                    # LANG=C to get a reliable output
+                    lang_bak = None
+                    if 'LANG' in os.environ:
+                        lang_bak = os.environ['LANG']
+                        os.environ['LANG'] = "C"
                     stash_text = self.helpers.safe_run(
                         self._get_scm_cmd() + ['stash'],
                         cwd=self.clone_dir)[1]
@@ -57,6 +63,8 @@ class Git(Scm):
                         text += self.helpers.safe_run(
                             self._get_scm_cmd() + ['stash', 'pop'],
                             cwd=self.clone_dir)[1]
+                    if lang_bak:
+                        os.environ['LANG'] = lang_bak
                 else:
                     text = self.helpers.safe_run(
                         self._get_scm_cmd() + ['reset', '--hard', rev],


### PR DESCRIPTION
Ensure that the call of "git stash" is done with LANG=C to get a reliable output.
Otherwise if --locale is set to something different then C/en_US it would result
in a different output string which would do a "git stash pop".

Fixes: #313