### PR TITLE
SCM/auth

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 exclude = tests
-ignore=E221,E251,E272,E241,E731,F401,E722
+ignore=E221,E251,E272,E241,E731,F401,E722,W503

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -187,6 +187,7 @@ dirs:
 	mkdir -p $(DESTDIR)$(mylibdir)/TarSCM
 	mkdir -p $(DESTDIR)$(mylibdir)/TarSCM/scm
 	mkdir -p $(DESTDIR)$(mycfgdir)
+	mkdir -p $(DESTDIR)$(mycfgdir)/tar_scm.d
 
 .PHONY: service
 service: dirs

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -61,8 +61,11 @@ class Cli():
                             choices=['git', 'hg', 'bzr', 'svn', 'tar'])
         parser.add_argument('--url',
                             help='Specify URL of upstream tarball to download')
-        parser.add_argument('--credential-key',
-                            help='Specify credential key from config file')
+        parser.add_argument('--user',
+                            help='Specify user for SCM authentication')
+        parser.add_argument('--keyring-passpharse',
+                            help='Specify passphrase to decrypt credentials '
+                                 'from keyring')
         parser.add_argument('--obsinfo',
                             help='Specify .obsinfo file to create a tar ball')
         parser.add_argument('--version', default='_auto_',

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -61,6 +61,8 @@ class Cli():
                             choices=['git', 'hg', 'bzr', 'svn', 'tar'])
         parser.add_argument('--url',
                             help='Specify URL of upstream tarball to download')
+        parser.add_argument('--credential-key',
+                            help='Specify credential key from config file')
         parser.add_argument('--obsinfo',
                             help='Specify .obsinfo file to create a tar ball')
         parser.add_argument('--version', default='_auto_',

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -63,7 +63,7 @@ class Cli():
                             help='Specify URL of upstream tarball to download')
         parser.add_argument('--user',
                             help='Specify user for SCM authentication')
-        parser.add_argument('--keyring-passpharse',
+        parser.add_argument('--keyring-passphrase',
                             help='Specify passphrase to decrypt credentials '
                                  'from keyring')
         parser.add_argument('--obsinfo',

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -20,12 +20,12 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-keyring_import_error=0
+keyring_import_error = 0
 
 try:
     import keyrings.alt.file
 except ImportError:
-    keyring_import_error=1
+    keyring_import_error = 1
 
 class Scm():
     def __init__(self, args, task):
@@ -51,8 +51,8 @@ class Scm():
         if args.user and args.keyring_passphrase:
             if keyring_import_error == 1:
                 raise SystemExit('Error while importing keyrings.alt.file but '
-                    '"--user" and "--keyring_passphrase" are set. '
-                    'Please install keyrings.alt.file!')
+                                 '"--user" and "--keyring_passphrase" are set.'
+                                 ' Please install keyrings.alt.file!')
             os.environ['XDG_DATA_HOME'] = '/etc/obs/services/tar_scm.d'
             _kr = keyrings.alt.file.EncryptedKeyring()
             _kr.keyring_key = args.keyring_passphrase

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -103,7 +103,7 @@ class Scm():
             pattern_proto = re.compile(auth_patterns[self.scm]['proto'])
             pattern = re.compile(auth_patterns[self.scm]['already'])
             if pattern_proto.match(self.url) and not pattern.match(self.url):
-                logging.debug('[auth_url] settings credentials from python keyring')
+                logging.debug('[auth_url] settings credentials from keyring')
                 self.url = re.sub(auth_patterns[self.scm]['sub'],
                                   auth_patterns[self.scm]['format'].format(
                                       user=self.user,

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -103,6 +103,7 @@ class Scm():
             pattern_proto = re.compile(auth_patterns[self.scm]['proto'])
             pattern = re.compile(auth_patterns[self.scm]['already'])
             if pattern_proto.match(self.url) and not pattern.match(self.url):
+                logging.debug('[auth_url] settings credentials from python keyring')
                 self.url = re.sub(auth_patterns[self.scm]['sub'],
                                   auth_patterns[self.scm]['format'].format(
                                       user=self.user,

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -53,6 +53,7 @@ class Scm():
                 raise SystemExit('Error while importing keyrings.alt.file but '
                     '"--user" and "--keyring_passphrase" are set. '
                     'Please install keyrings.alt.file!')
+            os.environ['XDG_DATA_HOME'] = '/etc/obs/services/tar_scm.d'
             _kr = keyrings.alt.file.EncryptedKeyring()
             _kr.keyring_key = args.keyring_passphrase
             try:

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -53,9 +53,13 @@ class Scm():
         self.revision       = args.revision
         if args.credential_key:
             try:
-                creds = literal_eval(
-                    Config().get('credentials', args.credential_key)
-                )
+                cred_line = Config().get('credentials', args.credential_key)
+                if not cred_line:
+                    raise Exception(
+                        "No key \'%s\' in [credentials] section"
+                        % args.credential_key
+                    )
+                creds = literal_eval(cred_line)
             except NoSectionError:
                 raise Exception('No section [credentials] in config file')
             except NoOptionError:
@@ -66,11 +70,17 @@ class Scm():
             except SyntaxError:
                 raise Exception(
                     'Malformed credential dict, should look like "%s ='
-                    '{\'user\': \'XXX\', \'pwd\': \'YYY\'}"'
+                    ' {\'user\': \'XXX\', \'pwd\': \'YYY\'}"'
                     % args.credential_key
                 )
             self.user     = creds.get('user')
             self.password = creds.get('pwd')
+            if not self.user or not self.password:
+                raise Exception(
+                    'Malformed credential dict, should look like "%s ='
+                    ' {\'user\': \'XXX\', \'pwd\': \'YYY\'}"'
+                    % args.credential_key
+                )
 
         # preparation of required attributes
         self.helpers        = Helpers()

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -10,7 +10,9 @@ import time
 import subprocess
 import glob
 import locale
+
 from ast import literal_eval
+
 # python3 renaming of ConfigParser
 try:
     from configparser import NoSectionError

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -15,6 +15,17 @@ class Bzr(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for bzr."""
+        if self.user and self.password:
+            pattern_proto = re.compile(r'^(ftp|bzr|https?)://.*')
+            pattern = re.compile(r'^(ftp|bzr|https?)://.*:.*@.*')
+            if (pattern_proto.fullmatch(self.url)
+                    and not pattern.fullmatch(self.url)):
+                self.url = re.sub(r'^((ftp|bzr|https?)://)(.*)',
+                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
+                                      user=self.user,
+                                      pwd=self.password),
+                                  self.url)
+
         command = self._get_scm_cmd() + ['checkout', self.url, self.clone_dir]
         if self.revision:
             command.insert(3, '-r')

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -18,8 +18,7 @@ class Bzr(Scm):
         if self.user and self.password:
             pattern_proto = re.compile(r'^(ftp|bzr|https?)://.*')
             pattern = re.compile(r'^(ftp|bzr|https?)://.*:.*@.*')
-            if (pattern_proto.fullmatch(self.url)
-                    and not pattern.fullmatch(self.url)):
+            if pattern_proto.match(self.url) and not pattern.match(self.url):
                 self.url = re.sub(r'^((ftp|bzr|https?)://)(.*)',
                                   r'\g<1>{user}:{pwd}@\g<3>'.format(
                                       user=self.user,

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -15,16 +15,8 @@ class Bzr(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for bzr."""
-        if self.user and self.password:
-            pattern_proto = re.compile(r'^(ftp|bzr|https?)://.*')
-            pattern = re.compile(r'^(ftp|bzr|https?)://.*:.*@.*')
-            if pattern_proto.match(self.url) and not pattern.match(self.url):
-                self.url = re.sub(r'^((ftp|bzr|https?)://)(.*)',
-                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
-                                      user=self.user,
-                                      pwd=self.password),
-                                  self.url)
 
+        self.auth_url()
         command = self._get_scm_cmd() + ['checkout', self.url, self.clone_dir]
         if self.revision:
             command.insert(3, '-r')

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -113,13 +113,13 @@ class Git(Scm):
     def fetch_submodules(self):
         """Recursively initialize git submodules."""
         argsd = self.args.__dict__
-        if ('submodules' in argsd and argsd['submodules'] == 'enable'):
+        if 'submodules' in argsd and argsd['submodules'] == 'enable':
             self.helpers.safe_run(
                 self._get_scm_cmd() + ['submodule', 'update', '--init',
                                        '--recursive'],
                 cwd=self.clone_dir
             )
-        elif ('submodules' in argsd and argsd['submodules'] == 'master'):
+        elif 'submodules' in argsd and argsd['submodules'] == 'master':
             self.helpers.safe_run(
                 self._get_scm_cmd() + ['submodule', 'update', '--init',
                                        '--recursive', '--remote'],
@@ -129,7 +129,7 @@ class Git(Scm):
     def fetch_lfs(self):
         """Initialize git lfs objects."""
         argsd = self.args.__dict__
-        if ('lfs' in argsd and argsd['lfs'] == 'enable'):
+        if 'lfs' in argsd and argsd['lfs'] == 'enable':
             self.helpers.safe_run(
                 self._get_scm_cmd() + ['lfs', 'fetch'],
                 cwd=self.clone_dir
@@ -172,7 +172,7 @@ class Git(Scm):
             logging.error("Corrupt clone_dir '%s' detected.", self.clone_dir)
             obs_service_daemon = os.getenv('OBS_SERVICE_DAEMON')
             osc_version = os.getenv('OSC_VERSION')
-            if (obs_service_daemon and not osc_version):
+            if obs_service_daemon and not osc_version:
                 logging.info("Removing corrupt cache!")
                 shutil.rmtree(self.clone_dir)
                 self.fetch_upstream_scm()

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -84,15 +84,7 @@ class Git(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for git."""
-        if self.user and self.password:
-            pattern_proto = re.compile(r'^(ftps?|https?)://.*')
-            pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
-            if pattern_proto.match(self.url) and not pattern.match(self.url):
-                self.url = re.sub(r'^((ftps?|https?)://)(.*)',
-                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
-                                      user=self.user,
-                                      pwd=self.password),
-                                  self.url)
+        self.auth_url()
         # clone if no .git dir exists
         command = self._get_scm_cmd() + ['clone', self.url, self.clone_dir]
         if not self.is_sslverify_enabled():
@@ -150,15 +142,7 @@ class Git(Scm):
     def update_cache(self):
         """Update sources via git."""
         # Force origin to the wanted URL in case it switched
-        if self.user and self.password:
-            pattern_proto = re.compile(r'^(ftps?|https?)://.*')
-            pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
-            if pattern_proto.match(self.url) and not pattern.match(self.url):
-                self.url = re.sub(r'^((ftps?|https?)://)(.*)',
-                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
-                                      user=self.user,
-                                      pwd=self.password),
-                                  self.url)
+        self.auth_url()
         try:
             self.helpers.safe_run(
                 self._get_scm_cmd() + ['config', 'remote.origin.url',

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -87,8 +87,7 @@ class Git(Scm):
         if self.user and self.password:
             pattern_proto = re.compile(r'^(ftps?|https?)://.*')
             pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
-            if (pattern_proto.fullmatch(self.url)
-                    and not pattern.fullmatch(self.url)):
+            if pattern_proto.match(self.url) and not pattern.match(self.url):
                 self.url = re.sub(r'^((ftps?|https?)://)(.*)',
                                   r'\g<1>{user}:{pwd}@\g<3>'.format(
                                       user=self.user,
@@ -154,8 +153,7 @@ class Git(Scm):
         if self.user and self.password:
             pattern_proto = re.compile(r'^(ftps?|https?)://.*')
             pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
-            if (pattern_proto.fullmatch(self.url)
-                    and not pattern.fullmatch(self.url)):
+            if pattern_proto.match(self.url) and not pattern.match(self.url):
                 self.url = re.sub(r'^((ftps?|https?)://)(.*)',
                                   r'\g<1>{user}:{pwd}@\g<3>'.format(
                                       user=self.user,

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -84,6 +84,16 @@ class Git(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for git."""
+        if self.user and self.password:
+            pattern_proto = re.compile(r'^(ftps?|https?)://.*')
+            pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
+            if (pattern_proto.fullmatch(self.url)
+                    and not pattern.fullmatch(self.url)):
+                self.url = re.sub(r'^((ftps?|https?)://)(.*)',
+                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
+                                      user=self.user,
+                                      pwd=self.password),
+                                  self.url)
         # clone if no .git dir exists
         command = self._get_scm_cmd() + ['clone', self.url, self.clone_dir]
         if not self.is_sslverify_enabled():
@@ -141,6 +151,16 @@ class Git(Scm):
     def update_cache(self):
         """Update sources via git."""
         # Force origin to the wanted URL in case it switched
+        if self.user and self.password:
+            pattern_proto = re.compile(r'^(ftps?|https?)://.*')
+            pattern = re.compile(r'^(ftps?|https?)://.*:.*@.*')
+            if (pattern_proto.fullmatch(self.url)
+                    and not pattern.fullmatch(self.url)):
+                self.url = re.sub(r'^((ftps?|https?)://)(.*)',
+                                  r'\g<1>{user}:{pwd}@\g<3>'.format(
+                                      user=self.user,
+                                      pwd=self.password),
+                                  self.url)
         try:
             self.helpers.safe_run(
                 self._get_scm_cmd() + ['config', 'remote.origin.url',

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -58,15 +58,7 @@ class Hg(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for hg."""
-        if self.user and self.password:
-            pattern_proto = re.compile(r'^https?://.*')
-            pattern = re.compile(r'^https?://.*:.*@.*')
-            if pattern_proto.match(self.url) and not pattern.match(self.url):
-                self.url = re.sub(r'^(https?://)(.*)',
-                                  r'\g<1>{user}:{pwd}@\g<2>'.format(
-                                      user=self.user,
-                                      pwd=self.password),
-                                  self.url)
+        self.auth_url()
         command = self._get_scm_cmd() + ['clone', self.url, self.clone_dir]
         if not self.is_sslverify_enabled():
             command += ['--insecure']

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -58,6 +58,16 @@ class Hg(Scm):
 
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for hg."""
+        if self.user and self.password:
+            pattern_proto = re.compile(r'^https?://.*')
+            pattern = re.compile(r'^https?://.*:.*@.*')
+            if (pattern_proto.fullmatch(self.url)
+                    and not pattern.fullmatch(self.url)):
+                self.url = re.sub(r'^(https?://)(.*)',
+                                  r'\g<1>{user}:{pwd}@\g<2>'.format(
+                                      user=self.user,
+                                      pwd=self.password),
+                                  self.url)
         command = self._get_scm_cmd() + ['clone', self.url, self.clone_dir]
         if not self.is_sslverify_enabled():
             command += ['--insecure']

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -61,8 +61,7 @@ class Hg(Scm):
         if self.user and self.password:
             pattern_proto = re.compile(r'^https?://.*')
             pattern = re.compile(r'^https?://.*:.*@.*')
-            if (pattern_proto.fullmatch(self.url)
-                    and not pattern.fullmatch(self.url)):
+            if pattern_proto.match(self.url) and not pattern.match(self.url):
                 self.url = re.sub(r'^(https?://)(.*)',
                                   r'\g<1>{user}:{pwd}@\g<2>'.format(
                                       user=self.user,

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -76,6 +76,10 @@ class Svn(Scm):
             cfg.close()
             scmcmd += ['--config-dir', self.svntmpdir]
 
+            if self.user and self.password:
+                scmcmd += ['--username', self.user]
+                scmcmd += ['--password', self.password]
+
         return scmcmd
 
     def fetch_upstream_scm(self):

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -113,7 +113,7 @@ class Svn(Scm):
         except SystemExit as exc:
             logging.warning("Could not update cache: >>>%s<<<!", exc.code)
             osd = os.getenv('OBS_SERVICE_DAEMON')
-            if (re.match(r".*run 'cleanup'.*", exc.code) and osd):
+            if re.match(r".*run 'cleanup'.*", exc.code) and osd:
                 logging.warning("Removing old cache dir '%s'!", self.clone_dir)
                 shutil.rmtree(self.clone_dir)
                 self.fetch_upstream_scm()

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
 Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
-Recommends: mercurial, git-buildpackage, git-lfs
+Recommends: mercurial, git-buildpackage, git-lfs, python-keyring, python-keyrings.alt
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
+Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all, python-keyring, python-keyrings.alt
 Recommends: mercurial, git-buildpackage, git-lfs
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -120,6 +120,8 @@ BuildRequires:  %{pyyaml_package}
 BuildRequires:  %{use_python}-argparse
 %endif
 BuildRequires:  %{use_python}-dateutil
+BuildRequires:  %{use_python}-keyring
+BuildRequires:  %{use_python}-keyrings.alt
 # Why do we need this? we dont use it as runtime requires later
 BuildRequires:  %{use_python}-lxml
 
@@ -149,6 +151,8 @@ Group:          Development/Tools/Building
 Requires:       %{locale_package}
 Requires:       %{pyyaml_package}
 Requires:       %{use_python}-dateutil
+Requires:  %{use_python}-keyring
+Requires:  %{use_python}-keyrings.alt
 %if %{with needs_external_argparse}
 Requires:       %{use_python}-argparse
 %endif

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -245,6 +245,7 @@ make %{use_test}
 %{_prefix}/lib/obs/service/tar_scm
 %dir %{_sysconfdir}/obs
 %dir %{_sysconfdir}/obs/services
+%attr(-,obsrun,obsrun) %dir %{_sysconfdir}/obs/services/tar_scm.d
 %config(noreplace) %{_sysconfdir}/obs/services/*
 
 %files -n obs-service-tar

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -245,7 +245,7 @@ make %{use_test}
 %{_prefix}/lib/obs/service/tar_scm
 %dir %{_sysconfdir}/obs
 %dir %{_sysconfdir}/obs/services
-%attr(-,obsrun,obsrun) %dir %{_sysconfdir}/obs/services/tar_scm.d
+%attr(-,obsservicerun,obsrun) %dir %{_sysconfdir}/obs/services/tar_scm.d
 %config(noreplace) %{_sysconfdir}/obs/services/*
 
 %files -n obs-service-tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ PyYAML
 six
 pylint
 flake8
+keyring
+keyrings.alt

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -37,6 +37,19 @@
     <description>Specify URL to checkout.</description>
     <required/>
   </parameter>
+  <parameter name="credential-key">
+    <description>
+      Specify the credential key as used in config file to authenticate against SCM.
+      Its only available for the following combinaison of SCM / protocols:
+        - git: ftp(s),http(s)
+        - svn
+        - bzr: bzr,ftp,http(s)
+        - hg: http(s)
+      Here is an example of how to setup the config file( default to /etc/obs/services/tar_scm):
+      [credentials]
+      myrepo1 = {'user':'user1', 'pwd':'password1'}
+    </description>
+  </parameter>
   <parameter name="subdir">
     <description>Package just a subdirectory.</description>
   </parameter>

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -37,17 +37,21 @@
     <description>Specify URL to checkout.</description>
     <required/>
   </parameter>
-  <parameter name="credential-key">
+  <parameter name="user">
     <description>
-      Specify the credential key as used in config file to authenticate against SCM.
+      Specify the username to be used for authentication to the repository.
+    </description>
+  </parameter>
+  <parameter name="keyring-passphrase">
+    <description>
+    Specify the passphrase to decrypt credentials from the python keyring.
+    To store credentials please use the following command line:
+    "sudo su -H -u obsrun keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
       Its only available for the following combinaison of SCM / protocols:
         - git: ftp(s),http(s)
         - svn
         - bzr: bzr,ftp,http(s)
         - hg: http(s)
-      Here is an example of how to setup the config file( default to /etc/obs/services/tar_scm):
-      [credentials]
-      myrepo1 = {'user':'user1', 'pwd':'password1'}
     </description>
   </parameter>
   <parameter name="subdir">

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -46,7 +46,8 @@
     <description>
     Specify the passphrase to decrypt credentials from the python keyring.
     To store credentials please use the following command line:
-    "sudo su -H -u obsrun keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
+    "sudo mkdir /usr/lib/obs/.local && sudo chown obsservicerun /usr/lib/obs/.local"
+    "sudo su -H -u obsservicerun keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
       Its only available for the following combinaison of SCM / protocols:
         - git: ftp(s),http(s)
         - svn

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -46,8 +46,7 @@
     <description>
     Specify the passphrase to decrypt credentials from the python keyring.
     To store credentials please use the following command line:
-    "sudo mkdir /usr/lib/obs/.local && sudo chown obsservicerun /usr/lib/obs/.local"
-    "sudo su -H -u obsservicerun keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
+    "sudo su -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
       Its only available for the following combinaison of SCM / protocols:
         - git: ftp(s),http(s)
         - svn

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -46,7 +46,7 @@
     <description>
     Specify the passphrase to decrypt credentials from the python keyring.
     To store credentials please use the following command line:
-    "sudo su -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d keyring -b keyrings.alt.file.EncryptedKeyring set URL username password"
+    "sudo -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d keyring -b keyrings.alt.file.EncryptedKeyring set URL username"
       Its only available for the following combinaison of SCM / protocols:
         - git: ftp(s),http(s)
         - svn

--- a/tests/fake_classes.py
+++ b/tests/fake_classes.py
@@ -5,6 +5,7 @@ class FakeCli(dict):  # pylint: disable=no-init,too-few-public-methods
         self.changesgenerate = False
         self.subdir          = ''
         self.match_tag       = match_tag
+        self.credential_key  = ''
 
 
 class FakeTasks():  # pylint: disable=no-init,too-few-public-methods

--- a/tests/fake_classes.py
+++ b/tests/fake_classes.py
@@ -1,12 +1,12 @@
 class FakeCli(dict):  # pylint: disable=no-init,too-few-public-methods
     def __init__(self, match_tag=False):
-        self.url               = ''
-        self.revision          = ''
-        self.changesgenerate   = False
-        self.subdir            = ''
-        self.match_tag         = match_tag
-        self.user              = ''
-        self.keyring_passprase = ''
+        self.url                = ''
+        self.revision           = ''
+        self.changesgenerate    = False
+        self.subdir             = ''
+        self.match_tag          = match_tag
+        self.user               = ''
+        self.keyring_passphrase = ''
 
 
 class FakeTasks():  # pylint: disable=no-init,too-few-public-methods

--- a/tests/fake_classes.py
+++ b/tests/fake_classes.py
@@ -1,11 +1,12 @@
 class FakeCli(dict):  # pylint: disable=no-init,too-few-public-methods
     def __init__(self, match_tag=False):
-        self.url             = ''
-        self.revision        = ''
-        self.changesgenerate = False
-        self.subdir          = ''
-        self.match_tag       = match_tag
-        self.credential_key  = ''
+        self.url               = ''
+        self.revision          = ''
+        self.changesgenerate   = False
+        self.subdir            = ''
+        self.match_tag         = match_tag
+        self.user              = ''
+        self.keyring_passprase = ''
 
 
 class FakeTasks():  # pylint: disable=no-init,too-few-public-methods


### PR DESCRIPTION
Use python keyring (especially keyrings.alt encrypted file backend) to store/retrieve SCM credentials. The keyring cli has to be used (or keyring lib) to store, ie:

`sudo -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d keyring -b keyrings.alt.file.EncryptedKeyring set https://github.com/jjacque/obs-service-tar_scm.git user1`
This command will interactively prompt you to set the keyring passphrase if it's called for the first time and prompt you for the password you want to store for the service/user combinaison.

It allows users to specify the user to be used in _service file with:
`<param name="user">user1</param>`
`<param name="keyring-passphrase">XXX</param>`

It rewrites source url for hg, bzr, git and use --username/--password for svn.
It aims to give an answer to https://github.com/openSUSE/obs-service-tar_scm/issues/286 as the issue is pretty common.