### PR TITLE
fix situation when revision has been modified in _service

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -51,10 +51,18 @@ class Git(Scm):
                 cwd=self.clone_dir)[1]
 
             # merge may fail when not a remote branch, that is fine
-            self.helpers.run_cmd(
+            rcode, output = self.helpers.run_cmd(
                 self._get_scm_cmd() + ['merge', 'origin/' + self.revision],
                 cwd=self.clone_dir,
                 interactive=True)
+
+            # we must test also merge a possible local tag/branch
+            # because the user may have changed the revision in _service file
+            if rcode != 0 and 'not something we can merge' in output:
+                self.helpers.run_cmd(
+                    self._get_scm_cmd() + ['merge', self.revision],
+                    cwd=self.clone_dir,
+                    interactive=True)
 
             # validate the existens of the revision
             if self.revision and not self._ref_exists(self.revision):


### PR DESCRIPTION
to a tag (not a remote branch), but local checkout still follows
a different tag.

The merge just failed, since origin/$tag does not exist. We do
a local merge in that case now to switch to the new revision.