### PR TITLE
fix #boo 1168573 (obsservicerun,obsrun) not exists in client side ins…

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -92,8 +92,8 @@ Recommends:     %{use_python}-keyrings.alt                      \
 ######## END OF MACROS AND FUN ###################################
 
 Name:           obs-service-tar_scm
-%define version_unconverted 0.10.14.1583853599.ccbb399
-Version:        0.10.14.1583853599.ccbb399
+%define version_unconverted 0.10.14.1587475802.e92a47f
+Version:        0.10.14.1587475802.e92a47f
 Release:        0
 Summary:        An OBS source service: create tar ball from svn/git/hg
 License:        GPL-2.0-or-later
@@ -249,7 +249,7 @@ make %{use_test}
 %{_prefix}/lib/obs/service/tar_scm
 %dir %{_sysconfdir}/obs
 %dir %{_sysconfdir}/obs/services
-%attr(-,obsservicerun,obsrun) %dir %{_sysconfdir}/obs/services/tar_scm.d
+%verify (not user group) %dir %{_sysconfdir}/obs/services/tar_scm.d
 %config(noreplace) %{_sysconfdir}/obs/services/*
 
 %files -n obs-service-tar

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -45,7 +45,8 @@
   <parameter name="keyring-passphrase">
     <description>
     Specify the passphrase to decrypt credentials from the python keyring.
-    To store credentials please use the following command line:
+    To store credentials please use the following command lines:
+    "sudo chown obsservicerun:obsrun /etc/obs/services/tar_scm.d"
     "sudo -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d keyring -b keyrings.alt.file.EncryptedKeyring set URL username"
       Its only available for the following combinaison of SCM / protocols:
         - git: ftp(s),http(s)


### PR DESCRIPTION
…tallation

This PR fixes #boo 1168573.

* switched ownership of /etc/obs/services/tar_scm.d back to (root, root)
* disabled verification of (user, group) for "rpm --verify"
* enhanced documentation in ".service" file, to ensure correct ownership
  of /etc/obs/services/tar_scm.d in "server side" installation.

Other conclusions:

* Running services depending on keyring managers inside containers may
  break, but this use case is not considered ATM.