### PR TITLE
Build with python 3 for Debian and Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: obs-service-tar-scm
 Section: devel
 Priority: extra
 Maintainer: Daniel Gollub <dgollub@brocade.com>
-Build-Depends: debhelper (>= 7.0.0), python (>= 2.6), python-argparse | python (>= 2.7), python-dateutil
+Build-Depends: debhelper (>= 7.0.0), python3, python3-dateutil, dh-python
 Standards-Version: 3.9.3
 Homepage: https://github.com/openSUSE/obs-service-tar_scm
 X-Python-Version: >= 2.6
@@ -10,7 +10,7 @@ X-Python-Version: >= 2.6
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar
-Depends: ${misc:Depends}, ${python:Depends}, bzr, git, subversion, cpio, python-dateutil, python-yaml, locales-all
+Depends: ${misc:Depends}, ${python3:Depends}, bzr, git, subversion, cpio, python3-dateutil, python3-yaml, locales-all
 Recommends: mercurial, git-buildpackage, git-lfs
 Description: An OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 DESTDIR=debian/obs-service-tar-scm
 
 %:
-	dh $@ --with python2
+	dh $@ --with python3
 
 override_dh_auto_build: ;
 


### PR DESCRIPTION
Ubuntu Next, Debian Testing and Unstable lacks some of required build depends, but they have python3 equivalents. All currently supported have also that depends, so maybe it's time to switch to python3. 