### PR TITLE
fix build for centos 8 (#374)

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -150,7 +150,7 @@ BuildRequires:  %{use_python}-lxml
 %if %{with python3}
 
 %if 0%{?centos_version} >= 800
-# ignore python3 dependency (nothing provides python3 error)
+# ignore python3 dependency (nothing provides python3-base error) github issue #374
 %else
 BuildRequires:  %{use_python}%{_pkg_base}
 %endif

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -148,7 +148,13 @@ BuildRequires:  %{use_python}-dateutil
 BuildRequires:  %{use_python}-lxml
 
 %if %{with python3}
+
+%if 0%{?centos_version} >= 800
+# ignore python3 dependency (nothing provides python3 error)
+%else
 BuildRequires:  %{use_python}%{_pkg_base}
+%endif
+
 # Fix missing Requires in python3-pbr in Leap42.3
 BuildRequires:  %{use_python}-setuptools
 %else


### PR DESCRIPTION
This fixes OBS build for CentOS 8
Probably needs better solutions, but it works. Example of working package: https://build.opensuse.org/package/show/home:oleg_antonyan/obs-service-tar_scm

Also, this must be in project config:
```
%if 0%{?centos_version} >= 800
Macros:
%_with_python3 1
:Macros
%endif
```
