### PR TITLE
Add new param --describe-candidates

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -184,6 +184,9 @@ class Cli():
         parser.add_argument('--maintainers-asc', default = False,
                             help='File which contains maintainers pubkeys. '
                                  '(only used with \'--latest-signed-*\')')
+        parser.add_argument('--describe-candidates', default=10,
+                            help='Choose the number of candidates to be '
+                                 'considered to describe the git input')
 
         self.verify_args(parser.parse_args(options))
 

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -263,7 +263,9 @@ class Git(Scm):
 
     def _detect_parent_tag(self, args=None):
         parent_tag = ''
-        cmd = self._get_scm_cmd() + ['describe', '--tags', '--abbrev=0']
+        cmd = self._get_scm_cmd() + ['describe', '--tags', '--abbrev=0',
+                                     '--candidates=%s' % \
+                                        self.args.describe_candidates]
         try:
             if args and args['match_tag']:
                 cmd.append("--match=%s" % args['match_tag'])

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -212,4 +212,7 @@ which get maintained in the SCM. Can be used multiple times.</description>
   <parameter name="maintainers-asc">
     <description>File which contains maintainers pubkeys (only used with '--latest-signed-*')</description>
   </parameter>
+  <parameter name="describe-candidates">
+    <description>Choose the number of candidates to be considered to describe the git input</description>
+  </parameter>
 </service>


### PR DESCRIPTION
This new parameter allows you to specify how many
candidates to consider to describe the git input.
We encountered a strange merge situation where
using this parameter was necessary.