### PR TITLE
Fix setting svn credentials in the command line

### DIFF
--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -76,9 +76,9 @@ class Svn(Scm):
             cfg.close()
             scmcmd += ['--config-dir', self.svntmpdir]
 
-            if self.user and self.password:
-                scmcmd += ['--username', self.user]
-                scmcmd += ['--password', self.password]
+        if self.user and self.password:
+            scmcmd += ['--username', self.user]
+            scmcmd += ['--password', self.password]
 
         return scmcmd
 


### PR DESCRIPTION
Fixes: 805922e7 ("Use cli params to set credentials for Subversion SCM")