### PR TITLE
fix indentation issue making auth for svn only enabled when proxy

### DIFF
--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -76,9 +76,9 @@ class Svn(Scm):
             cfg.close()
             scmcmd += ['--config-dir', self.svntmpdir]
 
-            if self.user and self.password:
-                scmcmd += ['--username', self.user]
-                scmcmd += ['--password', self.password]
+        if self.user and self.password:
+            scmcmd += ['--username', self.user]
+            scmcmd += ['--password', self.password]
 
         return scmcmd
 


### PR DESCRIPTION
@matwey noticed an issue with SVN auth: https://github.com/openSUSE/obs-service-tar_scm/pull/342#issuecomment-753465567
Due to an indentation error the user/password command line params are only added when proxy config is enabled.