### PR TITLE
package .gitignore files

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -17,7 +17,7 @@ try:
 except:
     from StringIO import StringIO
 
-METADATA_PATTERN = re.compile(r'.*/\.(bzr|git(ignore)?|hg|svn)(\/.*|$)')
+METADATA_PATTERN = re.compile(r'.*/\.(bzr|git|hg|svn)(\/.*|$)')
 
 
 class BaseArchive():


### PR DESCRIPTION
There is zero reason to omit .gitignore in the resulting tar.

Fixes commit bd1cb3dd0d4f5b635d0d2b9b952c6229b1e97b16

Signed-off-by: Olaf Hering <olaf@aepfle.de>