### PR TITLE
Remove code which corrupts versions

### DIFF
--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -38,7 +38,7 @@ class Bzr(Scm):
             interactive=sys.stdout.isatty()
         )
 
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen):
         """
         Automatic detection of version number for checked-out BZR repository.
         """

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -231,7 +231,7 @@ class Git(Scm):
                 logging.info("Please fix corrupt cache directory!")
                 raise exc
 
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen):
         """
         Automatic detection of version number for checked-out GIT repository.
         """
@@ -259,7 +259,9 @@ class Git(Scm):
                                    "--pretty=format:%s" % versionformat],
             self.clone_dir
         )[1]
-        return self.version_iso_cleanup(version, debian)
+        if truncate_at_hyphen:
+            version = self.version_iso_cleanup(version, debian)
+        return version
 
     def _detect_parent_tag(self, args=None):
         parent_tag = ''
@@ -308,7 +310,7 @@ class Git(Scm):
 
     def get_timestamp(self):
         data = {"parent_tag": None, "versionformat": "%ct"}
-        timestamp = self.detect_version(data)
+        timestamp = self.detect_version(data, False)
         return int(timestamp)
 
     def get_current_commit(self):

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -79,7 +79,7 @@ class Hg(Scm):
             if re.match('.*no changes found.*', str(exc)) is None:
                 raise
 
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen):
         """
         Automatic detection of version number for checked-out HG repository.
         """
@@ -126,11 +126,13 @@ class Hg(Scm):
         ])
 
         version = self.helpers.safe_run(cmd, self.clone_dir)[1]
-        return self.version_iso_cleanup(version)
+        if truncate_at_hyphen:
+            version = self.version_iso_cleanup(version)
+        return version
 
     def get_timestamp(self):
         data = {"parent_tag": None, "versionformat": "{date}"}
-        timestamp = self.detect_version(data)
+        timestamp = self.detect_version(data, True)
         timestamp = re.sub(r'([0-9]+)\..*', r'\1', timestamp)
         return int(timestamp)
 

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -122,7 +122,7 @@ class Svn(Scm):
             else:
                 raise exc
 
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen):
         """
         Automatic detection of version number for checked-out SVN repository.
         """

--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -48,7 +48,7 @@ class Tar(Scm):
         """Update sources via tar."""
         pass
 
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen):
         """Read former stored version."""
         return self.read_from_obsinfo(self.args.obsinfo, "version")
 

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -261,11 +261,14 @@ class Tasks():
         given as cli option and applying versionrewrite_pattern and
         versionprefix if given as cli option
         '''
+        truncate_at_hyphen = True
+        if self.args.versionrewrite_pattern:
+            truncate_at_hyphen = False
         version = self.args.version
         if version == '_none_':
             return ''
         if version == '_auto_' or self.args.versionformat:
-            version = self.detect_version()
+            version = self.detect_version(truncate_at_hyphen)
         if self.args.versionrewrite_pattern:
             regex = re.compile(self.args.versionrewrite_pattern)
             version = regex.sub(self.args.versionrewrite_replacement, version)
@@ -275,9 +278,9 @@ class Tasks():
         logging.debug("VERSION(auto): %s", version)
         return version
 
-    def detect_version(self):
+    def detect_version(self, truncate_at_hyphen = False):
         """Automatic detection of version number for checked-out repository."""
 
-        version = self.scm_object.detect_version(self.args.__dict__).strip()
+        version = self.scm_object.detect_version(self.args.__dict__, truncate_at_hyphen).strip()
         logging.debug("VERSION(auto): %s", version)
         return version

--- a/tests/fake_classes.py
+++ b/tests/fake_classes.py
@@ -21,5 +21,5 @@ class FakeSCM():
 
     # pylint: disable=unused-argument,no-self-use,no-init,
     # pylint: disable=too-few-public-methods
-    def detect_version(self, args):
+    def detect_version(self, args, truncate_at_hyphen = False):
         return self.version

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -215,7 +215,7 @@ class UnitTestCases(unittest.TestCase):
         # just to make coverage happy
         scm_object.update_cache()
         tstamp  = scm_object.get_timestamp()
-        ver     = scm_object.detect_version(self.cli)
+        ver     = scm_object.detect_version(self.cli, False)
         empty   = scm_object.read_from_obsinfo(info, "nonexistantkey")
 
         self.assertTrue(os.path.isdir(os.path.join(wdir, "test-0.1.1")))


### PR DESCRIPTION
A _service file which intends to use @PARENT_TAG@ for the package
version, and which uses versionrewrite-pattern to process the tag
further, will be unable to process the full tag name to extract the
desired parts of it via versionrewrite-replacement. The reason is the
forced removal of all hyphens.

It is up to the author of the _service file how the final package
version is assembled. versionrewrite-pattern and
versionrewrite-replacement give control how this needs to be done.

Remove all of the offending code, which should have been removed along
with the changes that introduced versionrewrite in commit
960d0cebad3bbf86102991eb38c542bbf5a16df4.

Fixes issue #367

Signed-off-by: Olaf Hering <olaf@aepfle.de>