### PR TITLE
Add option to not add version to tarball

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -105,6 +105,10 @@ class Cli():
         parser.add_argument('--extension', default='tar',
                             help='suffix name of package - used together with '
                                  'filename to determine tarball name')
+        parser.add_argument('--filename-add-version',
+                            choices=['enable', 'disable'], default='enable',
+                            help='whether to automatically append the version '
+                            'to the file name')
         parser.add_argument('--changesgenerate', choices=['enable', 'disable'],
                             default='disable',
                             help='Specify whether to generate changes file '
@@ -213,6 +217,7 @@ class Cli():
             sys.exit('--filename must not specify a path')
 
         # booleanize non-standard parameters
+        args.filename_add_version = bool(args.filename_add_version == 'enable')
         args.changesgenerate      = bool(args.changesgenerate == 'enable')
         args.package_meta         = bool(args.package_meta == 'yes')
         args.sslverify            = bool(args.sslverify != 'disable')

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -216,7 +216,8 @@ class Tasks():
 
         version = self.get_version()
         changesversion = version
-        if version and not sys.argv[0].endswith("/tar") \
+        if version and args.filename_add_version \
+           and not sys.argv[0].endswith("/tar") \
            and not sys.argv[0].endswith("/snapcraft") \
            and not sys.argv[0].endswith("/appimage"):
             if isinstance(dstname, bytes):

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -154,6 +154,11 @@
   <parameter name="extension">
     <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
   </parameter>
+  <parameter name="filename_add_version">
+    <description>whether to automatically append the version to the file name</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
   <parameter name="exclude">
     <description>Specify glob pattern to exclude when creating the tarball.</description>
   </parameter>


### PR DESCRIPTION
Allows to eg generate an obscpio with constant name which makes it
easier to update locally (avoids osc rm/osc add)