### PR TITLE
add date/time to logging output for better debugging

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -238,6 +238,7 @@ class Cli():
         # Allow forcing verbose mode from the environment; this
         # allows debugging when running "osc service disabledrun" etc.
         if bool(os.getenv('DEBUG_TAR_SCM')) or args.verbose:
+            logging.basicConfig(format='%(asctime)s %(message)s')
             logging.getLogger().setLevel(logging.DEBUG)
 
         for attr in args.__dict__.keys():


### PR DESCRIPTION
This patch is intended to improve the possibility to debug performance related issues by logging the date/time of DEBUG_TAR_SCM flag