### PR TITLE
Prevent KeyError in check_for_branch_request method

### DIFF
--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -154,12 +154,12 @@ class Tasks():
         # is it a branch request?
         ofh = open("_branch_request", "r")
         dat = json.load(ofh)
-        if dat['object_kind'] == 'merge_request':
+        if dat.get('object_kind') == 'merge_request':
             # gitlab merge request
             args.url = dat['project']['http_url']
             rev = dat['object_attributes']['source']['default_branch']
             args.revision = rev
-        elif dat['action'] == 'opened':
+        elif dat.get('action') == 'opened':
             # github pull request
             args.url = "https://github.com/"
             args.url += dat['pull_request']['head']['repo']['full_name']


### PR DESCRIPTION
Depending from where the webhook is coming (GitHub or GitLab)
either the `object_kind` or `action` key does not
exist in the json payload which leads to an
KeyError exception when trying to access them.
Using `get` to check for the keys on the dict prevents
this exception.

![Screenshot_2021-05-04 test-package](https://user-images.githubusercontent.com/22001671/117034601-c534a180-ad03-11eb-8c90-fa6bd1a90bca.png)
