### PR TITLE
TarScm: use owner/group root in  .obscpio files

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -68,7 +68,7 @@ class ObsCpio(BaseArchive):
         archivefile     = open(archivefilename, "w")
 
         # detect reproducible support
-        params = ['cpio', '--create', '--format=newc']
+        params = ['cpio', '--create', '--format=newc', '--owner', '0:0']
         chkcmd = "cpio --create --format=newc --reproducible "
         chkcmd += "</dev/null >/dev/null 2>&1"
         if os.system(chkcmd) == 0:


### PR DESCRIPTION
Currently, .obscpio archives contain the actual user/group IDs of the
user creating the archive. This causes generated files to be different
for service runs on different systems. In particular, the .obscpio will
be different between a service run on the server and a local run. This
is unfortunate when an automated build with default service mode is converted
to manual build for submission to a project which doesn't allow server-side
service runs, because the .obscpio will change if the service is run locally.

Fix this by changing owner and group in .obscpio files to root.