### PR TITLE
add '-- .' to git log command if file/dir equal revision exists

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -257,6 +257,10 @@ class Git(Scm):
         if self.revision:
             log_cmd.append('--source')
             log_cmd.append(self.revision)
+            revpath = os.path.join(self.clone_dir, self.revision)
+            if os.path.exists(revpath):
+                log_cmd.append('--')
+
         version = self.helpers.safe_run(log_cmd, self.clone_dir)[1]
         return version
 

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -374,3 +374,16 @@ class GitTests(GitHgTests, GitSvnTests):
         self.tar_scm_std("--without-version", "1")
         tar_path = os.path.join(self.outdir, 'repo.tar')
         self.assertTrue(os.path.isfile(tar_path))
+
+    def test_file_conflicts_revision(self):
+        fix = self.fixtures
+        fix.create_commits(2)
+        repo_path = fix.repo_path
+        os.chdir(repo_path)
+        os.mkdir("test")
+        with open("test/myfile.txt", 'w') as file:
+            file.write("just for testing")
+        fix.safe_run('add test') 
+        fix.safe_run('commit -m "added tests"') 
+        fix.safe_run('tag test') 
+        self.tar_scm_std("--revision", 'test')


### PR DESCRIPTION
Fixes #412

Without this patch obs-service-tar_scm fails with an error message like

```
fatal: ambiguous argument ...
```

if a file/directory named like a tag/branch/revision exists
in the git top level dir.

This patch adds '--' and '.' to the list of arguments of the "git log"
command if a revision is set and a file <clone_dir>/<revision> exists
to avoid errors like mentioned above.