### PR TITLE
Change date format from short to %Y%m%d.

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -252,7 +252,7 @@ class Git(Scm):
             versionformat = self._detect_version_tag_offset(
                 self._parent_tag,
                 versionformat)
-        log_cmd = self._get_scm_cmd() + ['log', '-n1', '--date=short',
+        log_cmd = self._get_scm_cmd() + ['log', '-n1', '--date=format:%Y%m%d',
                                          "--pretty=format:%s" % versionformat]
         if self.revision:
             log_cmd.append('--source')


### PR DESCRIPTION
Since commit 49bb443 ("don`t sanitize version if versionrewrite_pattern
is set") the dashes from the short date format get into the version
string when versionrewrite_pattern is specified.

Change the date format so that no dashes are included in the date to
start with so that we don't need to realy on the sanitization to remove
them again.

Fixes: #419
Fixes: 49bb443 ("don`t sanitize version if versionrewrite_pattern is set")
Signed-off-by: Michal Suchanek <msuchanek@suse.de>