### PR TITLE
Handle cases where git merge does not work

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -107,10 +107,23 @@ class Git(Scm):
         # we must test also merge a possible local tag/branch
         # because the user may have changed the revision in _service file
         if rcode != 0 and 'not something we can merge' in output:
-            self.helpers.run_cmd(
+            rcode, output = self.helpers.run_cmd(
                 self._get_scm_cmd() + ['merge', self.revision],
                 cwd=self.clone_dir,
                 interactive=True)
+
+            # still cant merge. do checkout
+            if rcode != 0 and 'not something we can merge' in output:
+                rcode, output = self.helpers.run_cmd(
+                    self._get_scm_cmd() + ['checkout', self.revision],
+                    cwd=self.clone_dir,
+                    interactive=True)
+
+                # something is really wrong.
+                # not even checkout can get us what we want.
+                if rcode != 0:
+                    sys.exit('Failed to merge or checkout revision: %s' %
+                             self.revision)
 
         # validate the existens of the revision
         if self.revision and not self._ref_exists(self.revision):


### PR DESCRIPTION
This can happen e.g. with

```xml
<param name="revision">somegithash</param>
```