### PR TITLE
Always use `git reset --hard <revision>`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,15 +47,15 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Lint with flake8
-        run: flake8
+        run: make flake8
 
       - name: Lint code with pylint
-        run: pylint --rcfile=.pylintrc ./tar_scm.py ./TarSCM/scm/bzr.py ./TarSCM/scm/svn.py ./TarSCM/exceptions.py ./TarSCM/__init__.py ./TarSCM/scm/git.py ./TarSCM/scm/hg.py ./TarSCM/scm/__init__.py ./TarSCM/cli.py ./TarSCM/tasks.py
+        run: make pylint
 
-      - name: Lint tests with pylint
-        run: pylint --rcfile=.pylinttestsrc ./tests/__init__.py ./tests/utils.py ./tests/tarfixtures.py ./tests/unittestcases.py ./tests/archiveobscpiotestcases.py ./tests/test.py ./tests/scmlogs.py ./tests/tartests.py
+      - name: Lint test with pylint
+        run: make pylinttest
 
       - name: Run tests
         run: |
           locale
-          TAR_SCM_TESTMODE=1 PYTHONPATH=. python tests/test.py
+          make test

--- a/.pylinttestsrc
+++ b/.pylinttestsrc
@@ -165,7 +165,6 @@ expected-line-ending-format=
 
 
 [TYPECHECK]
-
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
@@ -179,7 +178,7 @@ ignored-modules=
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,Fixtures,TestAssertions
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/KankuFile
+++ b/KankuFile
@@ -25,8 +25,8 @@ jobs:
       # https://build.opensuse.org/project/show/devel:kanku:immages
       # to find more official Images
       project: devel:kanku:images
-      repository: images_leap_15_1
-      package: openSUSE-Leap-15.1-JeOS
+      repository: images_leap_15_3
+      package: openSUSE-Leap-15.3-JeOS
       use_oscrc: 0
   -
     use_module: Kanku::Handler::ImageDownload

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -45,6 +45,7 @@ def check_locale(loc):
 class Cli():
     # pylint: disable=too-few-public-methods
     DEFAULT_AUTHOR = 'obs-service-tar-scm@invalid'
+    outdir = None
 
     def __init__(self):
         self.use_obs_scm = False

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -74,13 +74,13 @@ class Git(Scm):
             # Ensure that the call of "git stash" is done with
             # LANG=C to get a reliable output
             self._stash_and_merge()
-        else:
-            # is doing the checkout in a hard way
-            # may not exist before when using cache
-            self.helpers.safe_run(
-                self._get_scm_cmd() + ['reset', '--hard', self.revision],
-                cwd=self.clone_dir
-            )
+
+        # is doing the checkout in a hard way
+        # may not exist before when using cache
+        self.helpers.safe_run(
+            self._get_scm_cmd() + ['reset', '--hard', self.revision],
+            cwd=self.clone_dir
+        )
 
         # only update submodules if they have been enabled
         if os.path.exists(os.path.join(self.clone_dir, '.git', 'modules')):

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -335,9 +335,10 @@ class Git(Scm):
             cmd += ['--', subdir]
         return self.helpers.safe_run(cmd, cwd=self.clone_dir)[1]
 
-    def detect_changes_scm(self, subdir, chgs):
+    def detect_changes_scm(self, chgs):
         """Detect changes between GIT revisions."""
         last_rev = chgs['revision']
+        subdir = self.args.subdir
 
         if last_rev is None:
             last_rev = self._log_cmd(

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -160,10 +160,11 @@ class Svn(Scm):
         timestamp = dateutil.parser.parse(timestamp).strftime("%s")
         return int(timestamp)
 
-    def detect_changes_scm(self, subdir, chgs):
+    def detect_changes_scm(self, chgs):
         """Detect changes between SVN revisions."""
         last_rev = chgs['revision']
         first_run = False
+        subdir = self.args.subdir
         if subdir:
             clone_dir = os.path.join(self.clone_dir, subdir)
         else:
@@ -192,9 +193,9 @@ class Svn(Scm):
         chgs['lines'] = lines
         return chgs
 
-    def get_repocache_hash(self, subdir):
+    def get_repocache_hash(self):
         """Calculate hash fingerprint for repository cache."""
-        string = self.url + '/' + subdir
+        string = self.url + '/' + self.args.subdir
         return hashlib.sha256(string.encode('UTF-8')).hexdigest()
 
     def _get_log(self, clone_dir, revision1, revision2):

--- a/tests/archiveobscpiotestcases.py
+++ b/tests/archiveobscpiotestcases.py
@@ -37,7 +37,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         f_dir                = os.path.join(self.fixtures_dir, tc_name, 'repo')
         shutil.copytree(f_dir, c_dir)
         scmlogs              = ScmInvocationLogs('git', c_dir)
-        scmlogs.next('start-test') # pylint: disable=E1102
+        scmlogs.nextlog('start-test')
         fixture              = GitFixtures(c_dir, scmlogs)
         fixture.init()
         scm_object           = Git(self.cli, self.tasks)
@@ -54,7 +54,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         arch.create_archive(
             scm_object,
             cli      = self.cli,
-            basename = bname ,
+            basename = bname,
             dstname  = dst,
             version  = chgv
         )
@@ -63,11 +63,12 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         self.assertTrue(os.path.isfile(cpiofile))
         self.assertTrue(os.path.isfile(infofile))
         data = yaml.safe_load(open(infofile, 'r'))
-        self.assertDictEqual(data,{
-            'name': bname,
-            'version': chgv,
-            'mtime': 1234567890,
-            'commit': data['commit']})
+        self.assertDictEqual(
+            data, {
+                'name': bname,
+                'version': chgv,
+                'mtime': 1234567890,
+                'commit': data['commit']})
 
     def test_obscpio_extract_of(self):
         '''
@@ -152,7 +153,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         cl_name              = self.__class__.__name__
         c_dir                = os.path.join(self.tmp_dir, tc_name)
         scmlogs              = ScmInvocationLogs('git', c_dir)
-        scmlogs.next('start-test')  # pylint: disable=E1102
+        scmlogs.nextlog('start-test')
         fixture              = GitFixtures(c_dir, scmlogs)
         fixture.init()
         scm_object           = Git(self.cli, self.tasks)

--- a/tests/bzrfixtures.py
+++ b/tests/bzrfixtures.py
@@ -3,7 +3,7 @@
 import os
 
 from fixtures import Fixtures
-from utils    import mkfreshdir, run_bzr
+from utils    import run_bzr
 
 
 class BzrFixtures(Fixtures):
@@ -24,10 +24,11 @@ class BzrFixtures(Fixtures):
         os.chdir(self.repo_path)
         self.safe_run('init')
         self.safe_run('whoami "%s"' % self.name_and_email)
-        self.wd = self.repo_path
+        self.wdir = self.repo_path
         print("created repo %s" % self.repo_path)
 
-    def record_rev(self, wd, rev_num):
+    def record_rev(self, *args):
+        rev_num = args[0]
         self.revs[rev_num] = str(rev_num)
         self.scmlogs.annotate("Recorded rev %d" % rev_num)
 

--- a/tests/bzrtests.py
+++ b/tests/bzrtests.py
@@ -2,7 +2,6 @@
 
 from commontests import CommonTests
 from bzrfixtures import BzrFixtures
-from utils       import run_bzr
 
 
 class BzrTests(CommonTests):
@@ -34,8 +33,8 @@ class BzrTests(CommonTests):
         self.fixtures.create_commits(4)
         self.tar_scm_std('--versionformat', 'foo%r', '--revision', self.rev(2))
         basename = self.basename(version='foo2')
-        th = self.assertTarOnly(basename)
-        self.assertTarMemberContains(th, basename + '/a', '2')
+        tar = self.assertTarOnly(basename)
+        self.assertTarMemberContains(tar, basename + '/a', '2')
 
     def assertDirentsMtime(self, entries):
         '''Skip this test with bazaar because there seem to be no way to create

--- a/tests/fake_classes.py
+++ b/tests/fake_classes.py
@@ -1,13 +1,15 @@
+# -*- coding: utf-8 -*-
 class FakeCli(dict):  # pylint: disable=no-init,too-few-public-methods
+    url                = ''
+    revision           = ''
+    changesgenerate    = False
+    subdir             = ''
+    user               = ''
+    keyring_passphrase = ''
+    maintainers_asc = None
     def __init__(self, match_tag=False):
-        self.url                = ''
-        self.revision           = ''
-        self.changesgenerate    = False
-        self.subdir             = ''
+        super(FakeCli, self).__init__()  # pylint: disable=R1725
         self.match_tag          = match_tag
-        self.user               = ''
-        self.keyring_passphrase = ''
-        self.maintainers_asc = None
 
 
 class FakeTasks():  # pylint: disable=no-init,too-few-public-methods

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -155,3 +155,18 @@ class Fixtures:
         self.safe_run('commit -m"füfüfü nününü %d" %s' % (new_rev, date))
         self.record_rev(wd, new_rev)
         self.scmlogs.annotate("Created 1 commit; now at %s" % (new_rev))
+
+    def touch(self, fname, times=None):
+        with open(os.path.join(self.wd, fname), 'a'):
+           os.utime(fname, times)
+
+    def remove(self, fname):
+        os.remove(os.path.join(self.wd, fname))
+
+    def tag(self, tag):
+        self.safe_run('tag %s' % tag)
+
+    def commit_file_with_tag(self, tag, file):
+        self.touch(file)
+        self.create_commit(self.wd)
+        self.tag(tag)

--- a/tests/githgtests.py
+++ b/tests/githgtests.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
-
-import os
-
+# -*- coding: utf-8 -*-
+# pylint: disable=E1101
 from commontests import CommonTests
-from utils       import run_hg
 
 
 class GitHgTests(CommonTests):
@@ -22,12 +20,12 @@ class GitHgTests(CommonTests):
         self.assertTarOnly(
             self.basename(version=self.version(2)))
 
-    def test_versionformat_dateYYYYMMDD(self):
+    def test_versionformat_dateYYYYMMDD(self):  # pylint: disable=C0103
         self.tar_scm_std('--versionformat', self.yyyymmdd_format)
         self.assertTarOnly(
             self.basename(version=self.dateYYYYMMDD(self.rev(2))))
 
-    def test_versionformat_dateYYYYMMDDHHMMSS(self):
+    def test_versionformat_dateYYYYMMDDHHMMSS(self): # pylint: disable=C0103
         self.tar_scm_std('--versionformat', self.yyyymmddhhmmss_format)
         ver = self.dateYYYYMMDDHHMMSS(self.rev(2))
         print(ver)
@@ -55,5 +53,5 @@ class GitHgTests(CommonTests):
         self.tar_scm_std('--versionformat', self.abbrev_hash_format,
                          '--revision', self.rev(2))
         basename = self.basename(version=self.abbrev_sha1s(self.rev(2)))
-        th = self.assertTarOnly(basename)
-        self.assertTarMemberContains(th, basename + '/a', '2')
+        tar = self.assertTarOnly(basename)
+        self.assertTarMemberContains(tar, basename + '/a', '2')

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -410,19 +410,19 @@ class GitTests(GitHgTests, GitSvnTests):
 
         # enable osc mode
         os.environ['OSC_VERSION'] = "1"
-        self.tar_scm_std("--revision", '0.0.3')
+        self.tar_scm_std("--revision", '0.0.3', '--version', '0.0.3')
         # reset osc mode
         del os.environ['OSC_VERSION']
 
         # check result
         expected = [
-            'repo-1234567890.3b43614',
-            'repo-1234567890.3b43614/a',
-            'repo-1234567890.3b43614/c',
-            'repo-1234567890.3b43614/file.1',
-            'repo-1234567890.3b43614/file.3',
-            'repo-1234567890.3b43614/subdir',
-            'repo-1234567890.3b43614/subdir/b'
+            'repo-0.0.3',
+            'repo-0.0.3/a',
+            'repo-0.0.3/c',
+            'repo-0.0.3/file.1',
+            'repo-0.0.3/file.3',
+            'repo-0.0.3/subdir',
+            'repo-0.0.3/subdir/b'
         ]
-        tar = os.path.join(self.test_dir, 'out', 'repo-1234567890.3b43614.tar')
+        tar = os.path.join(self.test_dir, 'out', 'repo-0.0.3.tar')
         self.assertTarIsDeeply(tar, expected)

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import re
 import tarfile
-import textwrap
 import shutil
 import mock
 
@@ -16,8 +15,6 @@ from tests.fake_classes import FakeCli, FakeTasks
 
 from TarSCM.helpers     import Helpers
 from TarSCM.scm.git     import Git
-
-from utils              import run_git
 
 
 class GitTests(GitHgTests, GitSvnTests):
@@ -49,26 +46,26 @@ class GitTests(GitHgTests, GitSvnTests):
         return self.timestamps(self.rev(rev)).replace('-', '')
 
     # This comment line helps align lines with hgtests.py.
-    def dateYYYYMMDD(self, rev):
+    def dateYYYYMMDD(self, rev):  # pylint: disable=C0103
         dateobj = datetime.date.fromtimestamp(float(self.timestamps(rev)))
         return dateobj.strftime("%4Y%02m%02d")
 
     # This comment line helps align lines with hgtests.py.
-    def dateYYYYMMDDHHMMSS(self, rev):
+    def dateYYYYMMDDHHMMSS(self, rev):  # pylint: disable=C0103
         dateobj = datetime.datetime.fromtimestamp(float(self.timestamps(rev)))
         return dateobj.strftime("%4Y%02m%02dT%02H%02M%02S")
 
     def rev(self, rev):
-        f = self.fixtures
-        return f.revs[f.repo_path][rev]
+        fix = self.fixtures
+        return fix.revs[fix.repo_path][rev]
 
     def timestamps(self, rev):
-        f = self.fixtures
-        return f.timestamps[f.repo_path][rev]
+        fix = self.fixtures
+        return fix.timestamps[fix.repo_path][rev]
 
     def sha1s(self, rev):
-        f = self.fixtures
-        return f.sha1s[f.repo_path][rev]
+        fix = self.fixtures
+        return fix.sha1s[fix.repo_path][rev]
 
     def abbrev_sha1s(self, rev):
         return self.sha1s(rev)[0:7]
@@ -78,10 +75,10 @@ class GitTests(GitHgTests, GitSvnTests):
             return self.abbrev_sha1s('tag%d' % rev)
         return self.sha1s('tag%d' % rev)
 
-    def changesregex(self, rev):
-        return '\d{10}.%s' % rev
+    def changesregex(self, rev):  # pylint: disable=R0201
+        return '\d{10}.%s' % rev  # noqa: W605, pylint: disable=W1401
 
-    def tar_scm_args(self):
+    def tar_scm_args(self):  # pylint: disable=R0201
         scm_args = [
             '--changesgenerate', 'enable',
             '--versionformat', '0.6.%h',
@@ -91,10 +88,10 @@ class GitTests(GitHgTests, GitSvnTests):
     # N.B. --versionformat gets tested thoroughly in githgtests.py
 
     def test_parent_tag(self):
-        f = self.fixtures
-        f.create_commits(1)
-        base = f.get_metadata("%H")
-        f.create_commits(3)
+        fix = self.fixtures
+        fix.create_commits(1)
+        base = fix.get_metadata("%H")
+        fix.create_commits(3)
         self.tar_scm_std("--parent-tag", base,
                          "--versionformat", "@TAG_OFFSET@")
         self.assertTarOnly(self.basename(version="3"))
@@ -113,10 +110,10 @@ class GitTests(GitHgTests, GitSvnTests):
         repo_path = fix.repo_path
         submod_path = fix.submodule_path(submod_name)
 
-        self.scmlogs.next('submodule-create')
+        self.scmlogs.nextlog('submodule-create')
         fix.create_submodule(submod_name)
 
-        self.scmlogs.next('submodule-fixtures')
+        self.scmlogs.nextlog('submodule-fixtures')
         fix.create_commits(3, submod_path)
         fix.create_commits(2, submod_path)
 
@@ -124,18 +121,18 @@ class GitTests(GitHgTests, GitSvnTests):
         fix.safe_run('submodule add file://%s' % submod_path)
         new_rev = fix.next_commit_rev(repo_path)
         fix.do_commit(repo_path, new_rev, ['.gitmodules', submod_name])
-        fix.record_rev(repo_path, new_rev)
+        fix.record_rev(new_rev, repo_path)
         os.chdir(os.path.join(repo_path, submod_name))
         fix.safe_run('checkout tag3')
         os.chdir(repo_path)
         new_rev = fix.next_commit_rev(repo_path)
         fix.do_commit(repo_path, new_rev, ['.gitmodules', submod_name])
-        fix.record_rev(repo_path, new_rev)
+        fix.record_rev(new_rev, repo_path)
 
-    def _submodule_fixture_prepare_branch(self, branch):
+    def _submodule_fixture_prep_branch(self, branch):
         fix = self.fixtures
         repo_path = fix.repo_path
-        self.scmlogs.next('prepare-branch')
+        self.scmlogs.nextlog('prepare-branch')
         os.chdir(repo_path)
         fix.safe_run('checkout -b %s' % branch)
         fix.create_commits(3)
@@ -150,10 +147,10 @@ class GitTests(GitHgTests, GitSvnTests):
                          '--version', 'tag3')
         tar_path = os.path.join(self.outdir,
                                 self.basename(version='tag3') + '.tar')
-        th = tarfile.open(tar_path)
+        tar = tarfile.open(tar_path)
         submod_path = os.path.join(self.basename(version='tag3'),
                                    submod_name, 'a')
-        self.assertTarMemberContains(th, submod_path, '5')
+        self.assertTarMemberContains(tar, submod_path, '5')
 
     def test_submodule_disabled_update(self):
         submod_name = 'submod1'
@@ -164,15 +161,15 @@ class GitTests(GitHgTests, GitSvnTests):
                          '--version', 'tag3')
         tar_path = os.path.join(self.outdir,
                                 self.basename(version='tag3') + '.tar')
-        th = tarfile.open(tar_path)
-        self.assertRaises(KeyError, th.getmember, os.path.join(
+        tar = tarfile.open(tar_path)
+        self.assertRaises(KeyError, tar.getmember, os.path.join(
             self.basename(version='tag3'), submod_name, 'a'))
 
-    def test_submodule_in_different_branch(self):
+    def test_submodule_in_other_branch(self):
         submod_name = 'submod1'
 
         rev = 'build'
-        self._submodule_fixture_prepare_branch(rev)
+        self._submodule_fixture_prep_branch(rev)
         self._submodule_fixture(submod_name)
 
         self.tar_scm_std('--submodules', 'enable',
@@ -180,16 +177,16 @@ class GitTests(GitHgTests, GitSvnTests):
                          '--version', rev)
         tar_path = os.path.join(self.outdir,
                                 self.basename(version=rev) + '.tar')
-        th = tarfile.open(tar_path)
+        tar = tarfile.open(tar_path)
         submod_path = os.path.join(self.basename(version=rev),
                                    submod_name, 'a')
-        self.assertTarMemberContains(th, submod_path, '3')
+        self.assertTarMemberContains(tar, submod_path, '3')
 
-    def test_latest_submodule_in_different_branch(self):
+    def test_latest_submodule_in_other_branch(self):  # pylint: disable=C0103
         submod_name = 'submod1'
 
         rev = 'build'
-        self._submodule_fixture_prepare_branch(rev)
+        self._submodule_fixture_prep_branch(rev)
         self._submodule_fixture(submod_name)
 
         self.tar_scm_std('--submodules', 'master',
@@ -197,26 +194,27 @@ class GitTests(GitHgTests, GitSvnTests):
                          '--version', rev)
         tar_path = os.path.join(self.outdir,
                                 self.basename(version=rev) + '.tar')
-        th = tarfile.open(tar_path)
+        tar = tarfile.open(tar_path)
         submod_path = os.path.join(self.basename(version=rev),
                                    submod_name, 'a')
-        self.assertTarMemberContains(th, submod_path, '5')
+        self.assertTarMemberContains(tar, submod_path, '5')
 
     def _check_servicedata(self, expected_dirents=2, revision=2):
         expected_sha1 = self.sha1s('tag%d' % revision)
         dirents = self.assertNumDirents(self.outdir, expected_dirents)
         self.assertTrue('_servicedata' in dirents,
                         '_servicedata in %s' % repr(dirents))
-        sd = open(os.path.join(self.outdir, '_servicedata')).read()
-        expected = (r"\s*<servicedata>"
-                   r"\s*<service name=\"tar_scm\">"
-                   r"\s*<param name=\"url\">%s</param>" 
-                   r"\s*<param name=\"changesrevision\">([0-9a-f]{40})</param>" 
-                   r"\s*</service>" 
-                   r"\s*</servicedata>" % self.fixtures.repo_url)
-        m = re.match(expected, sd)
-        self.assertTrue(m, "\n'%s'\n!~ /%s/" % (sd, expected))
-        sha1 = m.group(1)
+        sdat = open(os.path.join(self.outdir, '_servicedata')).read()
+        expected = (
+            r"\s*<servicedata>"
+            r"\s*<service name=\"tar_scm\">"
+            r"\s*<param name=\"url\">%s</param>"
+            r"\s*<param name=\"changesrevision\">([0-9a-f]{40})</param>"
+            r"\s*</service>"
+            r"\s*</servicedata>" % self.fixtures.repo_url)
+        reg = re.match(expected, sdat)
+        self.assertTrue(reg, "\n'%s'\n!~ /%s/" % (sdat, expected))
+        sha1 = reg.group(1)
         self.assertEqual(sha1, expected_sha1)
 
     def test_updatecache_has_tag(self):
@@ -226,7 +224,7 @@ class GitTests(GitHgTests, GitSvnTests):
                          "--versionformat", "@PARENT_TAG@")
         self.assertTarOnly(self.basename(version="tag2"))
 
-        self.scmlogs.next('prepare-branch')
+        self.scmlogs.nextlog('prepare-branch')
         repo_path = fix.repo_path
         os.chdir(repo_path)
         fix.safe_run('checkout tag2')
@@ -237,7 +235,7 @@ class GitTests(GitHgTests, GitSvnTests):
         fix = self.fixtures
         fix.create_commits(2)
         self.tar_scm_std("--revision", 'tag2',
-                         "--versionrewrite-pattern", 'tag(\d+)',
+                         "--versionrewrite-pattern", 'tag(\d+)',  # noqa: W605,E501 pylint: disable=W1401
                          "--versionrewrite-replacement", '\\1-test',
                          "--versionformat", "@PARENT_TAG@")
         self.assertTarOnly(self.basename(version="2-test"))
@@ -263,7 +261,6 @@ class GitTests(GitHgTests, GitSvnTests):
         self.tar_scm_std("--match-tag", 'tag*',
                          "--versionformat", "@PARENT_TAG@",
                          "--use-obs-scm", '1')
-        # self.assertTarOnly(self.basename(version="tag4"))
 
     def test_gitlab_github_files(self):
         fix = self.fixtures
@@ -273,10 +270,8 @@ class GitTests(GitHgTests, GitSvnTests):
         os.chdir(repo_path)
         os.makedirs("./.gitlab")
         os.makedirs("./.github")
-        fh = open('./.gitlab/test', 'a')
-        fh.close()
-        fh = open('./.github/test', 'a')
-        fh.close()
+        fix.touch('./.gitlab/test')
+        fix.touch('./.github/test')
         fix.safe_run('add .')
         fix.safe_run('commit -a -m "github/gitlab"')
         fix.safe_run('tag gitlab_hub')
@@ -284,20 +279,12 @@ class GitTests(GitHgTests, GitSvnTests):
                          'gitlab_hub', "--versionformat", "@PARENT_TAG@")
         tar_path = os.path.join(self.outdir,
                                 self.basename(version='gitlab_hub') + '.tar')
-        th = tarfile.open(tar_path)
+        tar = tarfile.open(tar_path)
         submod_path = os.path.join(self.basename(version='gitlab_hub'))
-        print("...... th: %s" % th)
-        print("...... submod_path: %s" % submod_path)
-        self.assertTarMemberContains(th, os.path.join(
-            submod_path,
-            '.github/test'),
-            ''
-        )
-        self.assertTarMemberContains(th, os.path.join(
-            submod_path,
-            '.gitlab/test'),
-            ''
-        )
+        hub_path = os.path.join(submod_path, '.github/test')
+        lab_path = os.path.join(submod_path, '.gitlab/test')
+        self.assertTarMemberContains(tar, hub_path, '')
+        self.assertTarMemberContains(tar, lab_path, '')
 
     def test_no_parent_tag(self):
         fix = self.fixtures
@@ -323,7 +310,7 @@ class GitTests(GitHgTests, GitSvnTests):
 
     def test_changesgenerate_unicode(self):
         self._write_servicedata(2)
-        orig_changes = self._write_changes_file()
+        self._write_changes_file()
         self.fixtures.create_commit_unicode()
         rev = 3
 
@@ -352,19 +339,19 @@ class GitTests(GitHgTests, GitSvnTests):
         git.clone_dir = clone_dir
         with mock.patch.object(Helpers, 'safe_run') as mock_save_run:
             git.fetch_upstream_scm()
-            ((command,), kwargs) = mock_save_run.call_args
+            ((command,), kwargs) = mock_save_run.call_args  # noqa: E501 pylint: disable=W0612
             expected_command = [
-              'git', '-c', 'http.proxy=http://myproxy', 'clone', '--mirror',
-              clone_url, clone_dir]
+                'git', '-c', 'http.proxy=http://myproxy', 'clone', '--mirror',
+                clone_url, clone_dir]
             self.assertEqual(expected_command, command)
 
     def test_revision_latest_tag(self):
         fix = self.fixtures
-        fix.create_commit(fix.wd)
-        fix.create_commit(fix.wd)
+        fix.create_commit(fix.wdir)
+        fix.create_commit(fix.wdir)
         self.tar_scm_std("--revision", "@PARENT_TAG@")
-        self.assertTarOnly(self.basename(version="1234567890." +
-          fix.sha1s[fix.wd]["tag2"][:7]))
+        sha1 = fix.sha1s[fix.wdir]["tag2"][:7]
+        self.assertTarOnly(self.basename(version="1234567890." + sha1))
 
     def test_without_version(self):
         fix = self.fixtures
@@ -383,9 +370,9 @@ class GitTests(GitHgTests, GitSvnTests):
         os.mkdir("test")
         with open("test/myfile.txt", 'w') as file:
             file.write("just for testing")
-        fix.safe_run('add test') 
-        fix.safe_run('commit -m "added tests"') 
-        fix.safe_run('tag test') 
+        fix.safe_run('add test')
+        fix.safe_run('commit -m "added tests"')
+        fix.safe_run('tag test')
         self.tar_scm_std("--revision", 'test')
 
     def test_osc_reset_hard(self):
@@ -403,7 +390,7 @@ class GitTests(GitHgTests, GitSvnTests):
         # otherwise the git repo would only contain the .git dir and
         # git._stash_and_merge() would not be executed
         repo_dir = os.path.join(self.pkgdir, 'repo')
-        fix.safe_run('clone %s %s' % (fix.wd, repo_dir))
+        fix.safe_run('clone %s %s' % (fix.wdir, repo_dir))
 
         # disable cachedirectory (would not be used with osc by default)
         os.environ['CACHEDIRECTORY'] = ""

--- a/tests/hgfixtures.py
+++ b/tests/hgfixtures.py
@@ -3,7 +3,7 @@
 import os
 
 from fixtures import Fixtures
-from utils    import mkfreshdir, run_hg
+from utils    import run_hg
 
 
 class HgFixtures(Fixtures):
@@ -29,16 +29,17 @@ class HgFixtures(Fixtures):
         os.makedirs(self.repo_path)
         os.chdir(self.repo_path)
         self.safe_run('init')
-        c = open('.hg/hgrc', 'w')
-        c.write("[ui]\nusername = %s\n" % self.name_and_email)
-        c.close()
-        self.wd = self.repo_path
+        with open('.hg/hgrc', 'w') as rcf:
+            rcf.write("[ui]\nusername = %s\n" % self.name_and_email)
+
+        self.wdir = self.repo_path
         print("created repo %s" % self.repo_path)
 
     def get_metadata(self, formatstr):
         return self.safe_run('log -l1 --template "%s"' % formatstr)[0].decode()
 
-    def record_rev(self, wd, rev_num):
+    def record_rev(self, *args):
+        rev_num = args[0]
         tag = str(rev_num - 1)  # hg starts counting changesets at 0
         self.revs[rev_num] = tag
         epoch_secs, tz_delta_to_utc = \

--- a/tests/scm.py
+++ b/tests/scm.py
@@ -1,14 +1,7 @@
-import sys
 import os
-import argparse
-import inspect
-import re
-import copy
 import shutil
 import unittest
 import six
-
-from mock import MagicMock
 
 from TarSCM.scm.base import Scm
 
@@ -52,12 +45,12 @@ class SCMBaseTestCases(unittest.TestCase):
                 "test1"
             )
 
-        if (hasattr(ctx.exception, 'message')):
+        if hasattr(ctx.exception, 'message'):
             msg = ctx.exception.message
         else:
             msg = ctx.exception
 
-        self.assertRegexpMatches(str(msg), 'No such file or directory')
+        six.assertRegex(self, str(msg), 'No such file or directory')
 
         scm_base.prep_tree_for_archive("test1", basedir, "test2")
 

--- a/tests/scmlogs.py
+++ b/tests/scmlogs.py
@@ -66,7 +66,7 @@ class ScmInvocationLogs:
     def get_log_path(self, identifier):
         return os.path.join(self.test_dir, self.get_log_file(identifier))
 
-    def next(self, identifier=''):
+    def nextlog(self, identifier=''):
         self.counter += 1
         self.current_log_path = self.get_log_path(identifier)
         if os.path.exists(self.current_log_path):

--- a/tests/svntests.py
+++ b/tests/svntests.py
@@ -2,11 +2,9 @@
 
 import os
 import re
-import textwrap
 
 from gitsvntests import GitSvnTests
 from svnfixtures import SvnFixtures
-from utils       import run_svn
 
 
 class SvnTests(GitSvnTests):
@@ -26,13 +24,13 @@ class SvnTests(GitSvnTests):
     def default_version(self):
         return self.rev(2)
 
-    def changesrevision(self, rev, abbrev=False):
+    def changesrevision(self, rev, abbrev=False):  # noqa: E501 pylint: disable=W0613,R0201
         return rev
 
-    def changesregex(self, rev):
+    def changesregex(self, rev):  # pylint: disable=R0201
         return rev
 
-    def tar_scm_args(self):
+    def tar_scm_args(self):   # pylint: disable=R0201
         scm_args = [
             '--changesgenerate', 'enable',
             '--versionformat', '0.6.%r',
@@ -51,14 +49,14 @@ class SvnTests(GitSvnTests):
         self.fixtures.create_commits(4)
         self.tar_scm_std('--versionformat', 'foo%r', '--revision', self.rev(2))
         basename = self.basename(version='foo2')
-        th = self.assertTarOnly(basename)
-        self.assertTarMemberContains(th, basename + '/a', '2')
+        tar = self.assertTarOnly(basename)
+        self.assertTarMemberContains(tar, basename + '/a', '2')
 
-    def _check_servicedata(self, expected_dirents=2, revision=2):
+    def _check_servicedata(self, expected_dirents=2, revision=2):  # noqa: E501 pylint: disable=W0613
         dirents = self.assertNumDirents(self.outdir, expected_dirents)
         self.assertTrue('_servicedata' in dirents,
                         '_servicedata in %s' % repr(dirents))
-        sd = open(os.path.join(self.outdir, '_servicedata')).read()
+        sdat = open(os.path.join(self.outdir, '_servicedata')).read()
         expected = (
             r"<servicedata>"
             r"\s*<service name=\"tar_scm\">"
@@ -67,9 +65,9 @@ class SvnTests(GitSvnTests):
             r"\s*</service>"
             r"\s*</servicedata>" % self.fixtures.repo_url
         )
-        m = re.match(expected, sd)
-        if m:
+        reg = re.match(expected, sdat)
+        if reg:
             print("matched")
         else:
             print("matched not")
-        self.assertTrue(m, "\n'%s'\n!~ /%s/" % (sd, expected))
+        self.assertTrue(reg, "\n'%s'\n!~ /%s/" % (sdat, expected))

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,11 +1,9 @@
 from __future__ import print_function
 
-import sys
 import os
 import inspect
 import shutil
 import unittest
-import six
 from mock import MagicMock
 
 from tar_scm import TarSCM
@@ -62,7 +60,7 @@ class TasksTestCases(unittest.TestCase):
         tasks = TarSCM.Tasks(self.cli)
         tasks.generate_list()
         self._restore_cwd()
-        for k in expected:
+        for k in expected:  # pylint: disable=C0206
             self.assertEqual(tasks.task_list[0].__dict__[k], expected[k])
         self.assertEqual(len(tasks.task_list), 1)
 
@@ -82,7 +80,7 @@ class TasksTestCases(unittest.TestCase):
         tasks = TarSCM.Tasks(self.cli)
         tasks.generate_list()
         self._restore_cwd()
-        for k in expected:
+        for k in expected:  # pylint: disable=C0206
             self.assertEqual(tasks.task_list[0].__dict__[k], expected[k])
         self.assertEqual(len(tasks.task_list), 1)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -24,7 +24,6 @@ from tests.tartests import TarTestCases
 from tests.archiveobscpiotestcases import ArchiveOBSCpioTestCases
 
 
-
 def str_to_class(string):
     '''Convert string into class'''
     return getattr(sys.modules[__name__], string)

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# pylint: disable=C0103
 
 import os
 from pprint import pprint, pformat
@@ -19,8 +20,8 @@ class TestAssertions(unittest.TestCase):
     with operations which the tar_scm unit tests commonly need.
     """
 
-    def assertNumDirents(self, dir, expected, msg=''):
-        dirents = os.listdir(dir)
+    def assertNumDirents(self, wdir, expected, msg=''):
+        dirents = os.listdir(wdir)
         got = len(dirents)
         if len(msg) > 0:
             msg += "\n"
@@ -46,7 +47,7 @@ class TestAssertions(unittest.TestCase):
         directly change the mtime for an entry in the tarball.'''
         if sys.hexversion < 0x02070000:
             return
-        for i in range(0, len(entries)):
+        for i in range(len(entries)):
             self.assertEqual(entries[i].mtime, 1234567890)
 
     def assertDirents(self, entries, top):
@@ -102,32 +103,32 @@ class TestAssertions(unittest.TestCase):
         pprint(dirents)
 
         if dirents[0][-4:] == '.tar':
-            tar = dirents[0]
-            wd  = dirents[1]
+            tar  = dirents[0]
+            wdir = dirents[1]
         elif dirents[1][-4:] == '.tar':
-            tar = dirents[1]
-            wd  = dirents[0]
+            tar  = dirents[1]
+            wdir = dirents[0]
         else:
             self.fail('no .tar found in ' + self.outdir)
 
-        self.assertEqual(wd, dirname)
-        self.assertTrue(os.path.isdir(os.path.join(self.outdir, wd)),
+        self.assertEqual(wdir, dirname)
+        self.assertTrue(os.path.isdir(os.path.join(self.outdir, wdir)),
                         dirname + ' should be directory')
 
         return self.checkTar(tar, tarbasename, **kwargs)
 
-    def assertTarMemberContains(self, th, tarmember, contents):
-        f = th.extractfile(tarmember)
-        self.assertEqual(contents, f.read().decode())
+    def assertTarMemberContains(self, tar, tarmember, contents):
+        files = tar.extractfile(tarmember)
+        self.assertEqual(contents, files.read().decode())
 
     def assertRanInitialClone(self, logpath, loglines):
         self._find(logpath, loglines,
                    self.initial_clone_command, self.update_cache_command)
 
     def assertSSLVerifyFalse(self, logpath, loglines):
+        term = self.initial_clone_command + '.*' + self.sslverify_false_args
         self._find(logpath, loglines,
-                   self.initial_clone_command +
-                   '.*' + self.sslverify_false_args,
+                   term,
                    self.sslverify_false_args + 'true')
 
     def assertRanUpdate(self, logpath, loglines):

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -138,6 +138,13 @@ class TestAssertions(unittest.TestCase):
         self._find(logpath, loglines,
                    self.update_cache_command, should_not_find)
 
+    def assertTarIsDeeply(self, tar, expected):
+        th = tarfile.open(tar)
+        got = []
+        for mem in th.getmembers():
+            got.append(mem.name)
+        self.assertTrue(got == expected)
+
     def _find(self, logpath, loglines, should_find, should_not_find):
         found = False
         regexp = re.compile('^' + should_find)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,10 +1,10 @@
-import datetime
+# -*- coding: utf-8 -*-
+# pylint: disable=C0103
 import os
 import shutil
 import sys
-import logging
 import trace
-from utils import mkfreshdir, run_cmd
+from utils import mkfreshdir
 from scmlogs import ScmInvocationLogs
 import TarSCM
 
@@ -31,8 +31,8 @@ class TestEnvironment:
     def tar_scm_bin(cls):
         tar_scm = os.path.join(cls.tests_dir, '..', 'tar_scm.py')
         if not os.path.isfile(tar_scm):
-            raise RuntimeError("Failed to find tar_scm executable at " +
-                               tar_scm)
+            msg = "Failed to find tar_scm executable at " + tar_scm
+            raise RuntimeError(msg)
         return tar_scm
 
     @classmethod
@@ -47,12 +47,13 @@ class TestEnvironment:
         os.environ['TAR_SCM_CLEAN_ENV'] = 'yes'
         cls.is_setup = True
         print("--^-^-- end   setupClass for %s --^-^--" % cls.__name__)
-        print
+        print()
 
     def calcPaths(self):
         if not self._testMethodName.startswith('test_'):
-            raise RuntimeError("unexpected test method name: " +
-                               self._testMethodName)
+            msg = "unexpected test method name: " + self._testMethodName
+            raise RuntimeError(msg)
+
         self.test_dir  = os.path.join(self.tmp_dir,  self.scm, self.test_name)
         self.pkgdir    = os.path.join(self.test_dir, 'pkg')
         self.homedir   = os.path.join(self.test_dir, 'home')
@@ -60,11 +61,11 @@ class TestEnvironment:
         self.cachedir  = os.path.join(self.test_dir, 'cache')
 
     def setUp(self):
-        print
+        print()
         print("=" * 70)
         print(self._testMethodName)
         print("=" * 70)
-        print
+        print()
 
         self.test_name = self._testMethodName[5:]
 
@@ -75,14 +76,14 @@ class TestEnvironment:
         self.calcPaths()
 
         self.scmlogs = ScmInvocationLogs(self.scm, self.test_dir)
-        self.scmlogs.next('fixtures')
+        self.scmlogs.nextlog('fixtures')
 
         self.initDirs()
 
         self.fixtures = self.fixtures_class(self.test_dir, self.scmlogs)
         self.fixtures.setup()
 
-        self.scmlogs.next('start-test')
+        self.scmlogs.nextlog('start-test')
         self.scmlogs.annotate('Starting %s test' % self.test_name)
 
         os.putenv('CACHEDIRECTORY', self.cachedir)
@@ -93,9 +94,9 @@ class TestEnvironment:
         # pkgdir persists between tests to simulate real world use
         # (although a test can choose to invoke mkfreshdir)
         persistent_dirs = [self.pkgdir, self.homedir]
-        for d in persistent_dirs:
-            if not os.path.exists(d):
-                os.makedirs(d)
+        for i_dir in persistent_dirs:
+            if not os.path.exists(i_dir):
+                os.makedirs(i_dir)
 
         # Tests should not depend on the contents of $HOME
         os.putenv('HOME', self.homedir)
@@ -109,11 +110,11 @@ class TestEnvironment:
         os.environ['CACHEDIRECTORY'] = ""
 
     def tearDown(self):
-        print
+        print()
         print("--v-v-- begin tearDown for %s --v-v--" % self.test_name)
         self.postRun()
         print("--^-^-- end   tearDown for %s --^-^--" % self.test_name)
-        print
+        print()
 
     def postRun(self):
         self.service = {'mode': 'disabled'}
@@ -129,7 +130,7 @@ class TestEnvironment:
         """
 
         temp_dir = self.outdir
-        dir = self.pkgdir
+        pdir = self.pkgdir
         service = self.service
 
         # This code was copied straight out of osc/core.py's
@@ -137,17 +138,15 @@ class TestEnvironment:
         # --------- 8< --------- 8< --------- 8< --------- 8< ---------
         if service['mode'] == "disabled"  or \
            service['mode'] == "trylocal"  or \
-           service['mode'] == "localonly" or \
-           callmode == "local"            or \
-           callmode == "trylocal":
+           service['mode'] == "localonly":
             for filename in os.listdir(temp_dir):
                 shutil.move(os.path.join(temp_dir, filename),
-                            os.path.join(dir, filename))
+                            os.path.join(pdir, filename))
         else:
             for filename in os.listdir(temp_dir):
                 shutil.move(os.path.join(temp_dir, filename),
-                            os.path.join(dir,
-                                         "_service:" + name + ":" + filename))
+                            os.path.join(pdir,
+                                         "_service::" + filename))
         # --------- 8< --------- 8< --------- 8< --------- 8< ---------
 
     def tar_scm_std(self, *args, **kwargs):
@@ -196,29 +195,29 @@ class TestEnvironment:
                 trace=0,
                 count=0)
             tracer.runfunc(TarSCM.run)
-            #r = tracer.results()
-            #r.write_results(show_missing=True, coverdir=".")
-        except SystemExit as e:
-            print("raised system exit %r" % e)
-            if e.code == 0:
-                print("e.code is ok")
+            # r = tracer.results()
+            # r.write_results(show_missing=True, coverdir=".")
+        except SystemExit as exp:
+            print("raised system exit %r" % exp)
+            if exp.code == 0:
+                print("exp.code is ok")
                 ret = 0
                 succeeded = True
             else:
-                print("e.code is not 0")
-                sys.stderr.write(e.code)
+                print("exp.code is not 0")
+                sys.stderr.write(exp.code)
                 ret = 1
                 succeeded = False
-        except (NameError, AttributeError) as e:
-            sys.stderr.write(e)
+        except (NameError, AttributeError) as exp:
+            sys.stderr.write(exp)
             ret = 1
             succeeded = False
-        except Exception as e:
-            print("Raised Exception %r" % e)
-            if (hasattr(e, 'message')):
-                msg = e.message
+        except Exception as exp:
+            print("Raised Exception %r" % exp)
+            if hasattr(exp, 'message'):
+                msg = exp.message
             else:
-                msg = e
+                msg = exp
             sys.stderr.write(str(msg))
             ret = 1
             succeeded = False
@@ -239,10 +238,11 @@ class TestEnvironment:
             print("--v-v-- begin STDERR from tar_scm --v-v--")
             print(stderr)
             print("--^-^-- end   STDERR from tar_scm --^-^--")
-        print("succeeded: %r - should_succeed %r" % (succeeded, should_succeed))
+        print("succeeded: %r - should_succeed %r" %
+              (succeeded, should_succeed))
+        result = ("succeed" if should_succeed else "fail")
         self.assertEqual(succeeded, should_succeed,
-                         "expected tar_scm to " +
-                         ("succeed" if should_succeed else "fail"))
+                         "expected tar_scm to " + result)
 
         return (stdout, stderr, ret)
 

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -154,7 +154,8 @@ class UnitTestCases(unittest.TestCase):
         '''Test to get git repocache dir without subdir'''
         scm_object = Git(self.cli, self.tasks)
         scm_object.url = 'https://github.com/openSUSE/obs-service-tar_scm.git'
-        repohash = scm_object.get_repocache_hash(None)
+        scm_object.args.subdir = None
+        repohash = scm_object.get_repocache_hash()
         self.assertEqual(
             repohash,
             'c0f3245498ad916e9ee404acfd7aa59e29d53b7a063a8609735c1284c67b2161')
@@ -165,8 +166,9 @@ class UnitTestCases(unittest.TestCase):
         TarSCM.base.scm.get_repocache_hash
         '''
         scm_object = Git(self.cli, self.tasks)
+        scm_object.args.subdir = 'subdir'
         scm_object.url = 'https://github.com/openSUSE/obs-service-tar_scm.git'
-        repohash = scm_object.get_repocache_hash('subdir')
+        repohash = scm_object.get_repocache_hash()
         self.assertEqual(
             repohash,
             'c0f3245498ad916e9ee404acfd7aa59e29d53b7a063a8609735c1284c67b2161')
@@ -175,7 +177,8 @@ class UnitTestCases(unittest.TestCase):
         '''Test to get svn repocache dir without subdir'''
         scm_object = Svn(self.cli, self.tasks)
         scm_object.url = 'https://github.com/openSUSE/obs-service-tar_scm.git'
-        repohash = scm_object.get_repocache_hash('')
+        scm_object.args.subdir = ''
+        repohash = scm_object.get_repocache_hash()
         self.assertEqual(
             repohash,
             'd5a57bc8ad6a3ecbca514a1a6fb48e2c9ee183ceb5f7d42e9fd5836918bd540c')
@@ -187,7 +190,8 @@ class UnitTestCases(unittest.TestCase):
         '''
         scm_object = Svn(self.cli, self.tasks)
         scm_object.url = 'https://github.com/openSUSE/obs-service-tar_scm.git'
-        repohash = scm_object.get_repocache_hash('subdir')
+        scm_object.args.subdir = 'subdir'
+        repohash = scm_object.get_repocache_hash()
         self.assertEqual(
             repohash,
             'b9761648b96f105d82a97b8a81f1ca060b015a3f882ef9a55ae6b5bf7be0d48a')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,10 +29,12 @@ def run_cmd(cmd):
     os.environ['LC_ALL'] = 'C.utf-8'
     if six.PY3:
         cmd = cmd.encode('UTF-8')
-    proc = subprocess.Popen(cmd, shell=True,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                           )
+    proc = subprocess.Popen(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+
     (stdout, stderr) = proc.communicate()
     return (stdout, stderr, proc.returncode)
 


### PR DESCRIPTION
This patch fixes the problem that the working copy is not resetted to the revision if using tar_scm with `osc`