### PR TITLE
TarScm (cpio): fix symlink time stamps

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -118,7 +118,7 @@ class ObsCpio(BaseArchive):
         tstamp = self.helpers.get_timestamp(scm_object, args, topdir)
         for name in sorted(cpiolist):
             try:
-                os.utime(name, (tstamp, tstamp))
+                os.utime(name, (tstamp, tstamp), follow_symlinks=False)
             except OSError:
                 pass
             # bytes() break in python2 with a TypeError as it expects only 1


### PR DESCRIPTION
Symlinks in .obscpio archives don't have the source time stamp. This
may cause non-reproducible .obscpio files.
Fix this by using the "follow_symlinks" option of os.utime().
