### PR TITLE
unlink .lock file after unlocking the cache

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -375,6 +375,7 @@ class Scm():
         if self.lock_file and os.path.isfile(self.lock_file.name):
             fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
             self.lock_file.close()
+            os.unlink(self.lock_file.name)
             self.lock_file = None
 
     def finalize(self):

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -355,3 +355,11 @@ class UnitTestCases(unittest.TestCase):
         self.assertEqual(tc_name, bname)
         self.assertEqual('%s-%s' % (tc_name, version), dst)
         self.assertEqual(chgv, version)
+
+    def test_cache_locking(self):
+        scm     = Git(self.cli, self.tasks)
+        scm.clone_dir = '.'
+        scm.lock_cache()
+        fname = scm.lock_file.name
+        scm.unlock_cache()
+        assert os.path.exists(fname) == 0


### PR DESCRIPTION
Without this patch, the ".lock" file in the working directory does not
get removed.

FIXES: #436