### PR TITLE
staple pylint version lower than 2.14 because of breaking changes in …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pep8
 python-dateutil
 PyYAML
 six
-pylint
+pylint < 2.14
 flake8


### PR DESCRIPTION
…config