### PR TITLE
[dist] added Requires to python_path

### DIFF
--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -171,6 +171,7 @@ BuildRequires:  python >= 2.6
 #
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
+Requires:       %{python_path}
 
 %description
 This is a source service for openSUSE Build Service.


### PR DESCRIPTION
With this patch the configured python_path used in shebang is required
FIXES: #450