### PR TITLE
Fixed filtering of include/exclude when topdir has escape characters.

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -85,7 +85,7 @@ class ObsCpio(BaseArchive):
         # transform glob patterns to regular expressions
         includes  = ''
         excludes  = r'$.'
-        topdir_re = '(' + topdir + '/)('
+        topdir_re = '(' + re.escape(topdir) + '/)('
         if args.include:
             incl_arr = [fnmatch.translate(x + '*') for x in args.include]
             match_list = r'|'.join(incl_arr)


### PR DESCRIPTION
When a `topdir` contains escape characters, such as "libxml++", include or exclude filters will fail. It is necessary to escape `topdir`.