### PR TITLE
Fix Change Tar Archive to use gzip compression

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -161,7 +161,7 @@ class Tar(BaseArchive):
         args                = kwargs['cli']
         outdir              = args.outdir
         dstname             = kwargs['dstname']
-        extension           = (args.extension or 'tar')
+        extension           = (args.extension or 'tar.gz')
         exclude             = args.exclude
         include             = args.include
         package_metadata    = args.package_meta
@@ -224,7 +224,7 @@ class Tar(BaseArchive):
 
         out_file = os.path.join(outdir, dstname + '.' + extension)
 
-        with tarfile.open(out_file, "w", encoding=enc) as tar:
+        with tarfile.open(out_file, "w:gz", encoding=enc) as tar:
             try:
                 tar.add(topdir, recursive=False, filter=reset)
             except TypeError:


### PR DESCRIPTION
This commit modifies the Tar class in BaseArchive to output gzip-compressed tar files instead of uncompressed tar files. This change improves the efficiency of the archive process by reducing the size of the output files.

This change is backward compatible, as tar and gzip are standard on most systems and gzip decompression is automatically handled by tar when extracting the archive.