### PR TITLE
Feat add gzip compression option for tarball creation

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -161,7 +161,7 @@ class Tar(BaseArchive):
         args                = kwargs['cli']
         outdir              = args.outdir
         dstname             = kwargs['dstname']
-        extension           = (args.extension or 'tar.gz')
+        extension           = (args.extension or 'tar')
         exclude             = args.exclude
         include             = args.include
         package_metadata    = args.package_meta
@@ -170,6 +170,9 @@ class Tar(BaseArchive):
             args,
             scm_object.clone_dir
         )
+        
+        # Check the extension to set the correct tarfile mode
+        open_mode = "w:gz" if extension == 'tar.gz' else "w"
 
         incl_patterns = []
         excl_patterns = []
@@ -224,7 +227,7 @@ class Tar(BaseArchive):
 
         out_file = os.path.join(outdir, dstname + '.' + extension)
 
-        with tarfile.open(out_file, "w:gz", encoding=enc) as tar:
+        with tarfile.open(out_file, open_mode, encoding=enc) as tar:
             try:
                 tar.add(topdir, recursive=False, filter=reset)
             except TypeError:

--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -161,7 +161,7 @@ class Tar(BaseArchive):
         args                = kwargs['cli']
         outdir              = args.outdir
         dstname             = kwargs['dstname']
-        extension           = (args.extension or 'tar')
+        extension           = (args.extension or 'tar.gz')
         exclude             = args.exclude
         include             = args.include
         package_metadata    = args.package_meta
@@ -224,7 +224,7 @@ class Tar(BaseArchive):
 
         out_file = os.path.join(outdir, dstname + '.' + extension)
 
-        with tarfile.open(out_file, "w", encoding=enc) as tar:
+        with tarfile.open(out_file, "w:gz", encoding=enc) as tar:
             try:
                 tar.add(topdir, recursive=False, filter=reset)
             except TypeError:


### PR DESCRIPTION
This commit introduces the option to create a gzip compressed tarball when the 'tar.gz' extension is selected. 
The open mode for the tarfile is determined based on the chosen extension.

If the extension is 'tar.gz', a gzip compressed tarball will be created. 
Otherwise, a regular uncompressed tarball will be created.

This allows for greater flexibility when creating tarballs, 
without breaking existing setups that do not use gzip compression.