### PR TITLE
gbp: use --git-export

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -256,18 +256,14 @@ class Gbp(BaseArchive):
         cwd = os.getcwd()
         os.chdir(workdir)
 
-        if not args.revision:
-            revision = 'origin/master'
-        else:
-            revision = 'origin/' + args.revision
-
         command = ['gbp', 'buildpackage', '--git-notify=off',
                    '--git-force-create', '--git-cleaner="true"']
 
         # we are not on a proper local branch due to using git-reset but we
         # anyway use the --git-export option
         command.extend(['--git-ignore-branch',
-                        "--git-export=%s" % revision])
+                        "--git-export-dir=%s" % workdir,
+                        '--git-export=WC'])
 
         # gbp can load submodules without having to run the git command, and
         # will ignore submodules even if loaded manually unless this option is


### PR DESCRIPTION
`--git-export` only works when `--git-export-dir` is set.

As the service `scm_object` has already cloned and setup the appropriate revision in the working copy, and as the working copy of `debian/changelog` is modified, export the working-copy using the gbp special 'WC' identifier so this is preserved.

This also fixes an issue with the `debian/changelog` revision modification being lost if a deployment has global export hooks configured in `/etc/git-buildpackage/gbp.conf` and export enabled.