### PR TITLE
Support URL hostname in keyring

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -68,8 +68,13 @@ class Scm():
             try:
                 self.password = _kr.get_password(self.url, args.user)
                 if not self.password:
-                    raise Exception('No user {u} in keyring for service {s}'
-                                    .format(u=args.user, s=self.url))
+                    # try just the hostname
+                    url_netloc = urlparse(self.url)[1]
+                    self.password = _kr.get_password(url_netloc, args.user)
+                    if not self.password:
+                        raise Exception(
+                            'No user {u} in keyring for service {s}'
+                            .format(u=args.user, s=self.url))
             except AssertionError:
                 raise Exception('Wrong keyring passphrase')
             self.user     = args.user


### PR DESCRIPTION
Allows adding just a single entry to keyring for use by multiple packages, instead of having to add them with same username/password. Very useful when there are lots packages from same source accessed using the same credentials.

 https://github.com/foo/pkg1.git
 https://github.com/foo/pkg2.git
 https://github.com/bar/pkg3.git

can now share a single keyring entry for github if desire, with more specific full url taking priority if needed.

```
sudo -H -u obsservicerun XDG_DATA_HOME=/etc/obs/services/tar_scm.d \
keyring -b keyrings.alt.file.EncryptedKeyring \
set github.com user1
```

Extends very useful feature added in #342