### PR TITLE
cpio: Do not follow symlinks in 'touch'

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -118,7 +118,7 @@ class ObsCpio(BaseArchive):
         tstamp = self.helpers.get_timestamp(scm_object, args, topdir)
         for name in sorted(cpiolist):
             try:
-                os.utime(name, (tstamp, tstamp))
+                os.utime(name, (tstamp, tstamp), follow_symlinks=False)
             except OSError:
                 pass
             # bytes() break in python2 with a TypeError as it expects only 1


### PR DESCRIPTION
commit 46ae2cd7 introduced normalizing mtimes using `os.utime` - the same syscall as used by `touch`
but would erroneously change the target of symlinks instead of the symlink itself.

I tested it for `TarSCM/archive.py` - the other two occurences of `os.utime` probably don't make a difference right now as no symlinks are involved there.