### PR TITLE
do not skip "--reference" if package-meta ...

### DIFF
--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -421,7 +421,7 @@ class Git(Scm):
         use_reference = True
 
         try:
-            if self.args.package_meta:
+            if (self.args.package_meta and not self.partial_clone):
                 logging.info("Not using '--reference'")
                 use_reference = False
         except KeyError:


### PR DESCRIPTION
... is enabled and git's partial clone is used.

This should mainly be relevant for servers/containers running with caching enabled (export CACHEDIRECTORY=....)

Fixes: #495