### PR TITLE
debian: depend on brz instead of bzr

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Homepage: https://github.com/openSUSE/obs-service-tar_scm
 Package: obs-service-tar-scm
 Architecture: all
 Provides: obs-service-obs-scm, obs-service-tar, obs-service-gbp
-Depends: ${misc:Depends}, ${python3:Depends}, python3, bzr, git, subversion, cpio, python3-dateutil, python3-yaml, locales-all
-Recommends: mercurial, git-buildpackage, git-lfs
+Depends: ${misc:Depends}, ${python3:Depends}, python3, git, subversion, cpio, python3-dateutil, python3-yaml, locales-all
+Recommends: brz, mercurial, git-buildpackage, git-lfs
 Description: OBS source service: fetches SCM tarballs
  This is a source service for openSUSE Build Service.
  It supports downloading from svn, git, hg and bzr repositories.


### PR DESCRIPTION
bzr is a deprecated, transitional empty package, pointingn to brz, since Debian 11