### PR TITLE
Add --ignore-for-workflow parameter

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -234,6 +234,10 @@ class Cli():
                                  '(only used with \'--latest-signed-*\')')
         parser.add_argument('--without-version', default = False,
                             help='Do not add version to output file.')
+        parser.add_argument('--ignore-for-workflow', default = False,
+                            help='Do not override the sources when running OBS'
+                                 'SCM branch_package workflow. Useful for'
+                                 'auxiliary files such as recipes.')
 
         self.verify_args(parser.parse_args(options))
 

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -160,7 +160,7 @@ class Tasks():
         # the source supposed to be merged is more important then the code
         # referenced in the _service file.
         args = self.args
-        if not os.path.exists('_branch_request'):
+        if args.ignore_for_workflow or not os.path.exists('_branch_request'):
             return args
 
         # is it a branch request?

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -227,4 +227,7 @@ Can be used multiple times. Format: source:dest</description>
   <parameter name="without-version">
     <description>Do not add version to output file.</description>
   </parameter>
+  <parameter name="ignore-for-workflow">
+    <description>Do not override the sources when running OBS SCM branch_package workflow. Useful for auxiliary files such as recipes.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
When a _service contains multiple obs_scm entries, the OBS SCM workflow branch_package will cause all of them to be updated to the fork/commit of the workflow. But this is rarely what we want, as for example in the case where the source code to build is in one main repository (that should be overridden), but there are also auxiliary repositories where the packaging recipes are stored, and that should not be updated, as the references will be invalid.

This is making it impossible to use branch_package on PRs for the systemd upstream CI project:

https://build.opensuse.org/project/show/system:systemd

The new parameters allows me to configure the auxiliary sources to be skipped by the branch_package update.