### PR TITLE
Add new --extract-rename option

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -52,6 +52,24 @@ class BaseArchive():
 
                 shutil.copy2(src, outdir)
 
+    def extract_rename_from_archive(self, repodir, tuples, outdir):
+        """Extract and rename all files directly outside of the archive.
+        """
+        if tuples is None:
+            return
+
+        for pair in tuples:
+            path = os.path.join(repodir, pair.split(':')[0])
+
+            if not os.path.exists(path):
+                sys.exit("%s: No such file or directory" % path)
+
+            r_src = os.path.realpath(path)
+            if not r_src.startswith(repodir):
+                sys.exit("%s: tries to escape the repository" % path)
+
+            shutil.copy2(path, os.path.join(outdir, pair.split(':')[1]))
+
     def filter_files(self, filelist, topdir, args):
         """
         Filter filelist by exclude/include parameters

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -19,6 +19,30 @@ def contains_dotdot(files):
     return 0
 
 
+def validate_extract_rename(extract_rename):
+    if not extract_rename:
+        return True
+
+    if contains_dotdot(extract_rename):
+        print('--extract-rename is not allowed to contain ".."')
+        return False
+
+    for pair in extract_rename:
+        if '*' in pair:
+            print('--extract-rename is not allowed to contain wildcards')
+            return False
+
+        if pair.count(':') != 1:
+            print('--extract-rename must contain a single ":"')
+            return False
+
+        if len(pair.split(':')[0]) == 0 or len(pair.split(':')[1]) == 0:
+            print('--extract-rename source/destination files must not be empty')
+            return False
+
+    return True
+
+
 def check_locale(loc):
     try:
         aloc_tmp = subprocess.check_output(['locale', '-a'])
@@ -107,6 +131,13 @@ class Cli():
         parser.add_argument('--extract', action='append',
                             help='Extract a file directly. Useful for build'
                                  'descriptions')
+        parser.add_argument('--extract-rename', action='append',
+                            help='Extract a file directly and rename it.'
+                                 'Useful for build descriptions with'
+                                 'multibuild.'
+                                 'Format: <source>:<dest>'
+                                 'Does not support wildcards, must not'
+                                 'contain colons in the filenames.')
         parser.add_argument('--filename',
                             help='Name of package - used together with version'
                                  ' to determine tarball name')
@@ -228,6 +259,9 @@ class Cli():
 
         if contains_dotdot(args.extract):
             sys.exit('--extract is not allowed to contain ".."')
+
+        if not validate_extract_rename(args.extract_rename):
+            sys.exit('--extract-rename is not valid. Format: <source>:<dest>')
 
         if args.filename and "/" in args.filename:
             sys.exit('--filename must not specify a path')

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -250,6 +250,9 @@ class Tasks():
         arch.extract_from_archive(extract_src, args.extract,
                                   args.outdir)
 
+        arch.extract_rename_from_archive(extract_src, args.extract_rename,
+                                         args.outdir)
+
         arch.create_archive(
             scm_object,
             basename  = basename,

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -170,6 +170,11 @@
     <description>Specify a file/glob to be exported directly. Useful for build descriptions like spec files
 which get maintained in the SCM. Can be used multiple times.</description>
   </parameter>
+  <parameter name="extract-rename">
+    <description>Specify a file to be renamed and exported directly. Useful for build descriptions like spec files
+which get maintained in the SCM and are used with multibuild. Does not support wildcards and must contain only one colon.
+Can be used multiple times. Format: source:dest</description>
+  </parameter>
   <parameter name="package-meta">
     <description>Package the metadata of SCM to allow the user or OBS to update after un-tar. Please be aware that this parameter has precedence over the "exclude" paramter.</description>
     <allowedvalue>yes</allowedvalue>


### PR DESCRIPTION
Allows extracting a file and renaming it. Useful for Debian builds where the recipe file is in git, but the naming doesn't match OBS expectations: usually git stores debian/control but OBS wants debian.control. Also useful for multibuild, eg, to extract foo.spec to foo_TargetRepository.spec.