### PR TITLE
feat: allow service to ignore the _branch_request file

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -58,6 +58,7 @@ class Cli():
         self.user = None
         self.keyring_passphrase = None
         self.changesgenerate = False
+        self.ignore_branch_request = False
 
     def parse_args(self, options):
         parser = argparse.ArgumentParser(description='Git Tarballs')
@@ -195,6 +196,8 @@ class Cli():
                                  '(only used with \'--latest-signed-*\')')
         parser.add_argument('--without-version', default = False,
                             help='Do not add version to output file.')
+        parser.add_argument('--ignore-branch-request', default = False,
+                            help='Ignore branch request file.')
 
         self.verify_args(parser.parse_args(options))
 

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -183,8 +183,8 @@ class Tasks():
         '''
         do the work for a single task
         '''
-
-        self.args = self.check_for_branch_request()
+        if not self.args.ignore_branch_request:
+            self.args = self.check_for_branch_request()
 
         logging.basicConfig(format="%(message)s", stream=sys.stderr,
                             level=logging.INFO)

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -216,4 +216,7 @@ which get maintained in the SCM. Can be used multiple times.</description>
   <parameter name="without-version">
     <description>Do not add version to output file.</description>
   </parameter>
+  <parameter name="ignore-branch-request">
+    <description>Ignore branch request file.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Files may be fetched from multiple remote repositories

For example, pull source code from the source code repository and .spec files from another repository.