### PR TITLE
Use fnmatch again for excludes

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -61,7 +61,7 @@ class BaseArchive():
             incl_arr = [fnmatch.translate(x + '*') for x in args.include]
             includes = re_topdir % (re.escape(topdir), r'|'.join(incl_arr))
         if args.exclude:
-            excl_arr = [x for x in args.exclude]
+            excl_arr = [fnmatch.translate(x) for x in args.exclude]
             excludes = re_topdir % (re.escape(topdir), r'|'.join(excl_arr))
 
         # add topdir without filtering for now


### PR DESCRIPTION
According to the documentation, the value of the "excludes" parameter for obs_scm is a glob. But since commit 140a127 ("fix excludes for obscpio") the code treats this value as a regular expression, which leads to wrong matching results and may lead to python crashes if the glob expression starts with "*".

Fixes: https://github.com/openSUSE/obs-service-tar_scm/issues/520
Fixes: 140a127 ("fix excludes for obscpio")