### PR TITLE
remove check if obsinfo is None from tar service

### DIFF
--- a/TarSCM/scm/tar.py
+++ b/TarSCM/scm/tar.py
@@ -10,12 +10,6 @@ class Tar(Scm):
 
     def fetch_upstream(self):
         """SCM specific version of fetch_upstream for tar."""
-        if self.args.obsinfo is None:
-            files = glob.glob('*.obsinfo')
-            if files:
-                # or we refactor and loop about all on future
-                self.args.obsinfo = files[0]
-
         version = None
         if self.args.obsinfo:
             self.basename = self.clone_dir = self.read_from_obsinfo(


### PR DESCRIPTION
This check should be obsolete as TarSCM/tasks.py is already looping over all obsinfo file found in the directory and creates one task for each. SEE TarSCM/tasks.py:113