### PR TITLE
Issue 520

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -61,7 +61,7 @@ class BaseArchive():
             incl_arr = [fnmatch.translate(x + '*') for x in args.include]
             includes = re_topdir % (re.escape(topdir), r'|'.join(incl_arr))
         if args.exclude:
-            excl_arr = [x for x in args.exclude]
+            excl_arr = [fnmatch.translate(x) for x in args.exclude]
             excludes = re_topdir % (re.escape(topdir), r'|'.join(excl_arr))
 
         # add topdir without filtering for now

--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -57,9 +57,16 @@ class BaseArchive():
         excludes  = r'$.'
         re_topdir = '(%s)/(%s)'
 
+        if args.include_re:
+            includes = re_topdir % (re.escape(topdir), args.include_re)
+
+        if args.exclude_re:
+            excludes = re_topdir % (re.escape(topdir), args.exclude_re)
+
         if args.include:
             incl_arr = [fnmatch.translate(x + '*') for x in args.include]
             includes = re_topdir % (re.escape(topdir), r'|'.join(incl_arr))
+
         if args.exclude:
             excl_arr = [fnmatch.translate(x) for x in args.exclude]
             excludes = re_topdir % (re.escape(topdir), r'|'.join(excl_arr))

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -149,10 +149,18 @@ class Cli():
                            default=[], metavar='REGEXP',
                            help='Specifies subset of files/subdirectories to '
                                 'pack in the tarball (can be repeated)')
+        group.add_argument('--include-re',
+                           metavar='REGEXP',
+                           help='Specifies a regex pattern to match '
+                                'files/subdirectories to pack in the archive')
         group.add_argument('--exclude', action='append',
                            default=[], metavar='REGEXP',
                            help='Specifies excludes when creating the '
                                 'tarball (can be repeated)')
+        group.add_argument('--exclude-re',
+                           metavar='REGEXP',
+                           help='Specifies a regex pattern to exclude matching'
+                                ' files from the archive')
         parser.add_argument('--package-meta',
                             choices=['yes', 'no'], default='no',
                             help='Package the meta data of SCM to allow the '

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -155,10 +155,16 @@
     <description>Specify suffix name of package, which is used together with filename to determine tarball name.</description>
   </parameter>
   <parameter name="exclude">
-    <description>Specify glob pattern to exclude when creating the tarball.</description>
+    <description>Specify glob pattern to exclude when creating the archive.</description>
+  </parameter>
+  <parameter name="exclude-re">
+    <description>Specify regex pattern to exclude when creating the archive.</description>
   </parameter>
   <parameter name="include">
-    <description>Specify subset of files/subdirectories to pack in the tarball.</description>
+    <description>Specify subset of files/subdirectories to pack in the archive.</description>
+  </parameter>
+  <parameter name="include-re">
+    <description>Specifies a regex pattern to match files/subdirectories to pack in the archive.</description>
   </parameter>
   <parameter name="extract">
     <description>Specify a file/glob to be exported directly. Useful for build descriptions like spec files

--- a/tests/commontests.py
+++ b/tests/commontests.py
@@ -62,15 +62,15 @@ class CommonTests(TestEnvironment, TestAssertions):
                     self.basename() + '/subdir/b']
         self.assertTrue(tarents == expected)
 
-#  def test_tar_exclude_re(self):
-#      self.tar_scm_std('--exclude', '(a|c)')
-#      tar_file = os.path.join(self.outdir, self.basename()+'.tar')
-#      tar      = tarfile.open(tar_file)
-#      tarents  = tar.getnames()
-#      expected = [self.basename(),
-#                  self.basename() + '/subdir',
-#                  self.basename() + '/subdir/b']
-#      self.assertTrue(tarents == expected)
+    def test_tar_exclude_re(self):
+        self.tar_scm_std('--exclude-re', '(a|c)')
+        tar_file = os.path.join(self.outdir, self.basename()+'.tar')
+        tar      = tarfile.open(tar_file)
+        tarents  = tar.getnames()
+        expected = [self.basename(),
+                    self.basename() + '/subdir',
+                    self.basename() + '/subdir/b']
+        self.assertTrue(tarents == expected)
 
     def test_tar_include(self):
         self.tar_scm_std('--include', self.fixtures.subdir)
@@ -80,6 +80,16 @@ class CommonTests(TestEnvironment, TestAssertions):
         expected = [self.basename(),
                     self.basename() + '/subdir',
                     self.basename() + '/subdir/b']
+        self.assertTrue(tarents == expected)
+
+    def test_tar_include_re(self):
+        self.tar_scm_std('--include-re', '(a|c)')
+        tar_file = os.path.join(self.outdir, self.basename()+'.tar')
+        tar      = tarfile.open(tar_file)
+        tarents = tar.getnames()
+        expected = [self.basename(),
+                    self.basename() + '/a',
+                    self.basename() + '/c']
         self.assertTrue(tarents == expected)
 
     def test_obs_scm_exclude(self):

--- a/tests/commontests.py
+++ b/tests/commontests.py
@@ -62,15 +62,15 @@ class CommonTests(TestEnvironment, TestAssertions):
                     self.basename() + '/subdir/b']
         self.assertTrue(tarents == expected)
 
-    def test_tar_exclude_re(self):
-        self.tar_scm_std('--exclude', '(a|c)')
-        tar_file = os.path.join(self.outdir, self.basename()+'.tar')
-        tar      = tarfile.open(tar_file)
-        tarents  = tar.getnames()
-        expected = [self.basename(),
-                    self.basename() + '/subdir',
-                    self.basename() + '/subdir/b']
-        self.assertTrue(tarents == expected)
+#  def test_tar_exclude_re(self):
+#      self.tar_scm_std('--exclude', '(a|c)')
+#      tar_file = os.path.join(self.outdir, self.basename()+'.tar')
+#      tar      = tarfile.open(tar_file)
+#      tarents  = tar.getnames()
+#      expected = [self.basename(),
+#                  self.basename() + '/subdir',
+#                  self.basename() + '/subdir/b']
+#      self.assertTrue(tarents == expected)
 
     def test_tar_include(self):
         self.tar_scm_std('--include', self.fixtures.subdir)

--- a/tests/gitsvntests.py
+++ b/tests/gitsvntests.py
@@ -91,12 +91,13 @@ class GitSvnTests(CommonTests):
         self._check_servicedata(revision=3)
 
     def _new_change_entry_regexp(self, author, changes):  # pylint: disable=R0201
-        return textwrap.dedent("""\
-          ^-------------------------------------------------------------------
-          \w{3} \w{3} [ \d]\d \d\d:\d\d:\d\d [A-Z]{3} 20\d\d - %s
-
-          %s
-          """) % (author, changes)
+        regex = \
+          r"^-+\n" \
+          r"\w{3} \w{3} [ \d]\d \d\d:\d\d:\d\d [A-Z]{3} 20\d\d - %s\n" \
+          r"\n" \
+          r"%s\n" % (author, changes)
+        print(regex)
+        return regex
 
     def _check_changes(self, orig_changes, expected_changes_regexp):
         new_changes_file = os.path.join(self.outdir, 'pkg.changes')
@@ -160,12 +161,11 @@ class GitSvnTests(CommonTests):
         print("XXXX 4")
         expected_changes_regexp = self._new_change_entry_regexp(
             expected_author,
-            textwrap.dedent("""\
-              - Update to version 0.6.%s:
-                \* 5
-                \* 4
-                \* 3
-              """) % rev
+            r"- Update to version 0.6.%s:\n"
+            r"  \* 5\n"
+            r"  \* 4\n"
+            r"  \* 3\n"
+             % rev
         )
         self._check_changes(orig_changes, expected_changes_regexp)
 
@@ -190,12 +190,11 @@ class GitSvnTests(CommonTests):
         expected_author = self.fixtures.user_email
         expected_changes_regexp = self._new_change_entry_regexp(
             expected_author,
-            textwrap.dedent("""\
-              - Update to version %s:
-                \* 5
-                \* 4
-                \* 3
-              """) % ver_regex
+            r"- Update to version %s:\n"
+            r"  \* 5\n"
+            r"  \* 4\n"
+            r"  \* 3\n"
+            % ver_regex
         )
         self._check_changes(orig_changes, expected_changes_regexp)
 
@@ -220,12 +219,11 @@ class GitSvnTests(CommonTests):
         expected_author = self.fixtures.user_email
         expected_changes_regexp = self._new_change_entry_regexp(
             expected_author,
-            textwrap.dedent("""\
-              - Update to version 0.6.%s:
-                \* 8
-                \* 7
-                \* 6
-              """) % self.changesrevision(rev, abbrev=True)
+            r"- Update to version 0.6.%s:\n"
+            r"  \* 8\n"
+            r"  \* 7\n"
+            r"  \* 6\n"
+            % self.changesrevision(rev, abbrev=True)
         )
         self._check_changes(orig_changes, expected_changes_regexp)
 
@@ -254,11 +252,10 @@ class GitSvnTests(CommonTests):
         expected_author = self.fixtures.user_email
         expected_changes_regexp = self._new_change_entry_regexp(
             expected_author,
-            textwrap.dedent("""\
-              - Update to version 0.6.%s:
-                \* 5
-                \* 4
-                \* 3
-              """) % self.changesrevision(rev, abbrev=True)
+            r"- Update to version 0.6.%s:\n"
+            r"  \* 5\n"
+            r"  \* 4\n"
+            r"  \* 3\n"
+            % self.changesrevision(rev, abbrev=True)
         )
         self._check_changes(orig_changes, expected_changes_regexp)

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -84,7 +84,7 @@ class GitTests(GitHgTests, GitSvnTests):
         return self.sha1s('tag%d' % rev)
 
     def changesregex(self, rev):  # pylint: disable=R0201
-        return '\d{10}.%s' % rev  # noqa: W605, pylint: disable=W1401
+        return r'\d{10}.%s' % rev  # noqa: W605, pylint: disable=W1401
 
     def tar_scm_args(self):  # pylint: disable=R0201
         scm_args = [
@@ -245,7 +245,7 @@ class GitTests(GitHgTests, GitSvnTests):
         fix = self.fixtures
         fix.create_commits(2)
         self.tar_scm_std("--revision", 'tag2',
-                         "--versionrewrite-pattern", 'tag(\d+)',  # noqa: W605,E501 pylint: disable=W1401
+                         "--versionrewrite-pattern", r'tag(\d+)',  # noqa: W605,E501 pylint: disable=W1401
                          "--versionrewrite-replacement", '\\1-test',
                          "--versionformat", "@PARENT_TAG@")
         self.assertTarOnly(self.basename(version="2-test"))


### PR DESCRIPTION
This PR includes the following features:

* FIX: #520 
* ADD: new  options `--include-re`/ `--exclude-re`
* FIX: various non-critical SyntaxWarning's

For the Record:
Here a detailed list of SyntaxWarning's

```
~/obs-service-tar_scm/tests/gittests.py:87: SyntaxWarning: invalid escape sequence '\d'
  return '\d{10}.%s' % rev  # noqa: W605, pylint: disable=W1401
~/obs-service-tar_scm/tests/gittests.py:248: SyntaxWarning: invalid escape sequence '\d'
  "--versionrewrite-pattern", 'tag(\d+)',  # noqa: W605,E501 pylint: disable=W1401
~/obs-service-tar_scm/tests/gitsvntests.py:96: SyntaxWarning: invalid escape sequence '\w'
  \w{3} \w{3} [ \d]\d \d\d:\d\d:\d\d [A-Z]{3} 20\d\d - %s
~/obs-service-tar_scm/tests/gitsvntests.py:165: SyntaxWarning: invalid escape sequence '\*'
  \* 5
~/obs-service-tar_scm/tests/gitsvntests.py:195: SyntaxWarning: invalid escape sequence '\*'
  \* 5
~/obs-service-tar_scm/tests/gitsvntests.py:225: SyntaxWarning: invalid escape sequence '\*'
  \* 8
~/obs-service-tar_scm/tests/gitsvntests.py:259: SyntaxWarning: invalid escape sequence '\*'
  \* 5
~/obs-service-tar_scm/tests/gitsvntests.py:96: SyntaxWarning: invalid escape sequence '\w'
  \w{3} \w{3} [ \d]\d \d\d:\d\d:\d\d [A-Z]{3} 20\d\d - %s
~/obs-service-tar_scm/tests/gitsvntests.py:165: SyntaxWarning: invalid escape sequence '\*'
  \* 5
~/obs-service-tar_scm/tests/gitsvntests.py:195: SyntaxWarning: invalid escape sequence '\*'
  \* 5
~/obs-service-tar_scm/tests/gitsvntests.py:225: SyntaxWarning: invalid escape sequence '\*'
  \* 8
~/obs-service-tar_scm/tests/gitsvntests.py:259: SyntaxWarning: invalid escape sequence '\*'
  \* 5
```
