### PR TITLE
Remove dependency on six

### DIFF
--- a/KankuFile
+++ b/KankuFile
@@ -47,7 +47,7 @@ jobs:
     options:
       commands:
         - zypper -n in git mercurial subversion make tar
-        - zypper -n in python3-PyYAML python3-python-dateutil python3-pylint python3-flake8 python3-six
+        - zypper -n in python3-PyYAML python3-python-dateutil python3-pylint python3-flake8
   -
     use_module: Kanku::Handler::ExecuteCommandViaSSH
     options:

--- a/dist/obs-service-tar_scm.spec
+++ b/dist/obs-service-tar_scm.spec
@@ -141,7 +141,6 @@ BuildRequires:  %{locale_package}
 BuildRequires:  %{pkg_name} = %{version}
 BuildRequires:  %{use_python}-keyring
 BuildRequires:  %{use_python}-keyrings.alt
-BuildRequires:  %{use_python}-six
 BuildRequires:  bzr
 BuildRequires:  git-core
 BuildRequires:  gpg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ mock; python_version < '3.3'
 pep8
 python-dateutil
 PyYAML
-six
 pylint < 2.14
 flake8

--- a/tests/archiveobscpiotestcases.py
+++ b/tests/archiveobscpiotestcases.py
@@ -7,7 +7,6 @@ import inspect
 import shutil
 import unittest
 import io
-import six
 import yaml
 
 import TarSCM
@@ -118,8 +117,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         outdir  = os.path.join(self.tmp_dir, cl_name, tc_name, 'out')
         arch    = ObsCpio()
         os.makedirs(outdir)
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile('No such file or directory'),
             arch.extract_from_archive,
@@ -140,8 +138,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
         outdir  = os.path.join(self.tmp_dir, cl_name, tc_name, 'out')
         arch    = TarSCM.archive.ObsCpio()
         os.makedirs(outdir)
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             IOError,
             re.compile('Is a directory:'),
             arch.extract_from_archive,
@@ -200,8 +197,7 @@ class ArchiveOBSCpioTestCases(unittest.TestCase):
 
         os.symlink("/", os.path.join(repodir, 'dir1'))
         arch    = TarSCM.archive.ObsCpio()
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile('tries to escape the repository'),
             arch.extract_from_archive,

--- a/tests/commontests.py
+++ b/tests/commontests.py
@@ -3,7 +3,6 @@
 from pprint               import pformat
 import os
 import tarfile
-import six
 
 from tests.testassertions import TestAssertions
 from tests.testenv        import TestEnvironment
@@ -50,7 +49,7 @@ class CommonTests(TestEnvironment, TestAssertions):
         tar_handle = self.assertTarOnly(basename)
         member     = tar_handle.getmember(basename + '/c')
         self.assertTrue(member.issym())
-        six.assertRegex(self, member.linkname, '[/.]*/nir/va/na$')
+        self.assertRegex(member.linkname, '[/.]*/nir/va/na$')
 
     def test_tar_exclude(self):
         self.tar_scm_std('--exclude', 'a', '--exclude', 'c')
@@ -117,26 +116,26 @@ class CommonTests(TestEnvironment, TestAssertions):
 
     def test_absolute_subdir(self):
         (_stdout, stderr, _ret) = self.tar_scm_std_fail('--subdir', '/')
-        six.assertRegex(
-            self, stderr, "Absolute path '/' is not allowed for --subdir")
+        self.assertRegex(
+            stderr, "Absolute path '/' is not allowed for --subdir")
 
     def test_subdir_parent(self):
         for path in ('..', '../', '../foo', 'foo/../../bar'):
             (_stdout, stderr, _ret) = self.tar_scm_std_fail('--subdir', path)
-            six.assertRegex(
-                self, stderr, "--subdir path '%s' must stay within repo" % path)
+            self.assertRegex(
+                stderr, "--subdir path '%s' must stay within repo" % path)
 
     def test_extract_parent(self):
         for path in ('..', '../', '../foo', 'foo/../../bar'):
             (_stdout, stderr, _ret) = self.tar_scm_std_fail('--extract', path)
-            six.assertRegex(
-                self, stderr, '--extract is not allowed to contain ".."')
+            self.assertRegex(
+                stderr, '--extract is not allowed to contain ".."')
 
     def test_filename(self):
         for path in ('/tmp/somepkg.tar', '../somepkg.tar'):
             (_stdout, stderr, _ret) = self.tar_scm_std_fail('--filename', path)
-            six.assertRegex(
-                self, stderr, '--filename must not specify a path')
+            self.assertRegex(
+                stderr, '--filename must not specify a path')
 
     def test_subdir(self):
         self.tar_scm_std('--subdir', self.fixtures.subdir)
@@ -144,7 +143,7 @@ class CommonTests(TestEnvironment, TestAssertions):
 
     def test_history_depth_obsolete(self):
         (stdout, _stderr, _ret) = self.tar_scm_std('--history-depth', '1')
-        six.assertRegex(self, stdout, 'obsolete')
+        self.assertRegex(stdout, 'obsolete')
 
     def test_myfilename(self):
         name = 'myfilename'

--- a/tests/gitsvntests.py
+++ b/tests/gitsvntests.py
@@ -6,7 +6,6 @@ import textwrap
 import re
 import shutil
 import glob
-import six
 
 from commontests import CommonTests
 
@@ -107,7 +106,7 @@ class GitSvnTests(CommonTests):
             self.assertNotEqual(orig_changes, new_changes)
             print(new_changes)
             expected_changes_regexp += "(.*)"
-            six.assertRegex(self, new_changes, expected_changes_regexp)
+            self.assertRegex(new_changes, expected_changes_regexp)
             reg = re.match(expected_changes_regexp, new_changes, re.DOTALL)
             self.assertEqual(reg.group(1), orig_changes)
 

--- a/tests/scm.py
+++ b/tests/scm.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import unittest
-import six
 
 from TarSCM.scm.base import Scm
 
@@ -50,7 +49,7 @@ class SCMBaseTestCases(unittest.TestCase):
         else:
             msg = ctx.exception
 
-        six.assertRegex(self, str(msg), 'No such file or directory')
+        self.assertRegex(str(msg), 'No such file or directory')
 
         scm_base.prep_tree_for_archive("test1", basedir, "test2")
 

--- a/tests/testassertions.py
+++ b/tests/testassertions.py
@@ -7,7 +7,6 @@ import re
 import sys
 import tarfile
 import unittest
-import six
 
 line_start = '(^|\n)'
 
@@ -162,10 +161,7 @@ class TestAssertions(unittest.TestCase):
                 "----\n%s\n----\n" \
                 % (should_not_find, logpath, "".join(loglines))
             if should_not_find:
-                if six.PY2:
-                    self.assertNotRegexpMatches(line, should_not_find, msg)
-                else:
-                    self.assertNotRegex(line, should_not_find, msg)
+                self.assertNotRegex(line, should_not_find, msg)
             if regexp.search(line):
                 found = True
         msg = \

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -6,7 +6,6 @@ import re
 import inspect
 import copy
 import unittest
-import six
 
 try:
     from unittest.mock import patch
@@ -81,8 +80,7 @@ class UnitTestCases(unittest.TestCase):
 
     def test_safe_run_exception(self):
         helpers = Helpers()
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile(r"Command /bin/false failed\(1\): ''"),
             helpers.safe_run,
@@ -299,8 +297,7 @@ class UnitTestCases(unittest.TestCase):
                  "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
         file_write_legacy(info, string)
         os.chdir(wdir)
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile("name in obsinfo contains '/'."),
             scm_object.fetch_upstream
@@ -313,8 +310,7 @@ class UnitTestCases(unittest.TestCase):
                  "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
         file_write_legacy(info, string)
         os.chdir(wdir)
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile("version in obsinfo contains '/' or '..'."),
             scm_object.fetch_upstream
@@ -327,8 +323,7 @@ class UnitTestCases(unittest.TestCase):
                  "commit: fea6eb5f43841d57424843c591b6c8791367a9e5\n"
         file_write_legacy(info, string)
         os.chdir(wdir)
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesRegex(
             SystemExit,
             re.compile("version in obsinfo contains '/' or '..'."),
             scm_object.fetch_upstream

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,6 @@ import io
 import shutil
 import subprocess
 import sys
-import six
 
 
 def mkfreshdir(path):
@@ -49,8 +48,6 @@ def run_cmd(cmd):
     use_locale = check_locale(["en_US.utf8", 'C.utf8'])
     os.environ['LANG']   = use_locale
     os.environ['LC_ALL'] = use_locale
-    if six.PY3:
-        cmd = cmd.encode('UTF-8')
     proc = subprocess.Popen(
         cmd,
         shell=True,


### PR DESCRIPTION
The main point is removal of the dependency on the `six` module. I have added also one small bug fix (in my opinion).