### PR TITLE
Support release candidate -RCx tag version

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -349,6 +349,9 @@ class Scm():
         # upstream vs downstream version
         # for RPM it has to be stripped instead, as it's an illegal character
         if not debian:
+            # support release candidate (RC) as non-sorting version with tilde
+            version = re.sub(r'-(RC|rc)(\d+)', r'~\1\2', version)
+            # strip any remaining dash '-' character(s)
             version = re.sub(r'[-:]', '', version)
         return version
 


### PR DESCRIPTION
RPM / fedora packaging supports non-sorting versions with tilde that can be used for any pre-release / Release Candidate versions. Tilde character is not supported in a git tag, so git tag can be set for example to 1.0.0-RC1 and the resulting tarball and RPM package will be:  my_package-1.0.0~RC1.tar.gz

For more details about non-sorting version with tilde symbol: 
https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret
