### PR TITLE
make sure that parameter "match_tag" is used

### DIFF
--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -54,6 +54,8 @@ class Scm():
         self.args           = args
         self.task           = task
         self.url            = args.url
+        self.org_url        = None
+        self.credentials_re = None
 
         self.in_osc = bool(os.getenv('OSC_VERSION'))
 
@@ -99,35 +101,22 @@ class Scm():
             self._revert_gpg_settings()
 
     def auth_url(self):
-        if self.scm not in ('bzr', 'git', 'hg'):
+        auth_patterns = {
+            'bzr' : r'^((?:ftp|bzr|https?)://)(.*)',
+            'git' : r'^((?:ftps?|https?)://)(.*)',
+            'hg'  : r'^(https?://)(.*)',
+        }
+
+        if self.org_url:
             return
-        auth_patterns = {}
-        auth_patterns['bzr'] = {}
-        auth_patterns['bzr']['proto']   = r'^(ftp|bzr|https?)://.*'
-        auth_patterns['bzr']['already'] = r'^(ftp|bzr|https?)://.*:.*@.*'
-        auth_patterns['bzr']['sub']     = r'^((ftp|bzr|https?)://)(.*)'
-        auth_patterns['bzr']['format']  = r'\g<1>{user}:{pwd}@\g<3>'
-        auth_patterns['git'] = {}
-        auth_patterns['git']['proto']   = r'^(ftps?|https?)://.*'
-        auth_patterns['git']['already'] = r'^(ftps?|https?)://.*:.*@.*'
-        auth_patterns['git']['sub']     = r'^((ftps?|https?)://)(.*)'
-        auth_patterns['git']['format']  = r'\g<1>{user}:{pwd}@\g<3>'
-        auth_patterns['hg'] = {}
-        auth_patterns['hg']['proto']   = r'^https?://.*'
-        auth_patterns['hg']['already'] = r'^https?://.*:.*@.*'
-        auth_patterns['hg']['sub']     = r'^(https?://)(.*)'
-        auth_patterns['hg']['format']  = r'\g<1>{user}:{pwd}@\g<2>'
+
+        if not auth_patterns.get(self.scm, None):
+            return
 
         if self.user and self.password:
-            pattern_proto = re.compile(auth_patterns[self.scm]['proto'])
-            pattern = re.compile(auth_patterns[self.scm]['already'])
-            if pattern_proto.match(self.url) and not pattern.match(self.url):
-                logging.debug('[auth_url] settings credentials from keyring')
-                self.url = re.sub(auth_patterns[self.scm]['sub'],
-                                  auth_patterns[self.scm]['format'].format(
-                                      user=self.user,
-                                      pwd=self.password),
-                                  self.url)
+            self.org_url = self.url
+            logging.debug('[auth_url] settings credentials from keyring')
+            self.url = re.sub(auth_patterns[self.scm], f"\\1{self.user}:{self.password}@\\2", self.url)
 
     def check_scm(self):
         '''check version of scm to proof, it is installed and executable'''
@@ -203,7 +192,8 @@ class Scm():
             for filename in glob.glob(old_changes_glob):
                 shutil.copy2(filename, os.getcwd())
 
-        chgs = self.changes.read_changes_revision(self.url, os.getcwd(),
+        url  = (self.org_url or self.url)
+        chgs = self.changes.read_changes_revision(url, os.getcwd(),
                                                   self.args.outdir)
 
         logging.debug("CHANGES: %s", repr(chgs))
@@ -414,6 +404,16 @@ class Scm():
 
     def check_url(self):
         return True
+
+    def run_and_hide(self, command, wdir, cleanup_dirs=[]):
+        try:
+            self.helpers.safe_run(
+                command, cwd=wdir, interactive=sys.stdout.isatty())
+        except SystemExit as exc:
+            for cdir in cleanup_dirs:
+                os.removedirs(cdir)
+            exc = re.sub(self.url, self.org_url, str(exc))
+            raise SystemExit(exc)
 
     def _prepare_gpg_settings(self):
         logging.debug("preparing gpg settings")

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -24,7 +24,7 @@ class Bzr(Scm):
         if not self.is_sslverify_enabled():
             command.insert(2, '-Ossl.cert_reqs=None')
         wdir = os.path.abspath(os.path.join(self.clone_dir, os.pardir))
-        self.helpers.safe_run(command, wdir, interactive=sys.stdout.isatty())
+        self.run_and_hide(command, wdir)
 
     def update_cache(self):
         """Update sources via bzr."""

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -283,7 +283,7 @@ class Git(Scm):
             versionformat = '%ct.%h'
 
         if not self._parent_tag:
-            self._parent_tag = self._detect_parent_tag(args)
+            self._parent_tag = self._detect_parent_tag()
 
         if re.match('.*@PARENT_TAG@.*', versionformat):
             versionformat = self._detect_version_parent_tag(
@@ -307,14 +307,12 @@ class Git(Scm):
         version = self.helpers.safe_run(log_cmd, self.clone_dir)[1]
         return version
 
-    def _detect_parent_tag(self, args=None):
+    def _detect_parent_tag(self):
         parent_tag = ''
         cmd = self._get_scm_cmd() + ['describe', '--tags', '--abbrev=0']
-        try:
-            if args and args['match_tag']:
-                cmd.append("--match=%s" % args['match_tag'])
-        except KeyError:
-            pass
+        if self.args.match_tag:
+            cmd.append("--match=%s" % self.args.match_tag)
+
         rcode, output = self.helpers.run_cmd(cmd, self.clone_dir)
 
         if rcode == 0:

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -460,6 +460,8 @@ class Git(Scm):
             refspec = self.revision + ":" + self.revision
             cmd = self._get_scm_cmd() + ['fetch', 'origin',
                                          refspec]
+            if self.partial_clone:
+                cmd.insert(-3, '--filter=tree:0')
             self.helpers.safe_run(
                 cmd, cwd=self.clone_dir, interactive=sys.stdout.isatty())
 

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -146,13 +146,10 @@ class Git(Scm):
             command += ['--config', 'http.sslverify=false']
         if self.repocachedir and not self.partial_clone:
             command.insert(command.index('clone') + 1, '--mirror')
+
         wdir = os.path.abspath(os.path.join(self.repodir, os.pardir))
-        try:
-            self.helpers.safe_run(
-                command, cwd=wdir, interactive=sys.stdout.isatty())
-        except SystemExit as exc:
-            os.removedirs(os.path.join(wdir, self.clone_dir))
-            raise exc
+        self.run_and_hide(command, wdir, [os.path.join(wdir, self.clone_dir)])
+
         if self.partial_clone:
             config_command = self._get_scm_cmd() + ['config', '--local',
                                                     'extensions.partialClone',
@@ -192,10 +189,7 @@ class Git(Scm):
             if self.partial_clone:
                 command.insert(-2, '--filter=tree:0')
             # fetch reference from url and create locally
-            self.helpers.safe_run(
-                command,
-                cwd=self.clone_dir, interactive=sys.stdout.isatty()
-            )
+            self.run_and_hide(command, self.clone_dir)
 
     def fetch_submodules(self):
         """Recursively initialize git submodules."""
@@ -255,11 +249,7 @@ class Git(Scm):
             if self.partial_clone:
                 command.append('--filter=tree:0')
 
-            self.helpers.safe_run(
-                command,
-                cwd=self.clone_dir,
-                interactive=sys.stdout.isatty()
-            )
+            self.run_and_hide(command, self.clone_dir)
 
         except SystemExit as exc:
             logging.error("Corrupt clone_dir '%s' detected.", self.clone_dir)
@@ -439,8 +429,9 @@ class Git(Scm):
             command.append(org_clone_dir)
         command.append(self.clone_dir)
         wdir = os.path.abspath(os.path.join(self.clone_dir, os.pardir))
-        self.helpers.safe_run(
-            command, cwd=wdir, interactive=sys.stdout.isatty())
+
+        self.run_and_hide(command, wdir)
+
         if self.partial_clone:
             config_command = self._get_scm_cmd() + ['config', '--local',
                                                     'extensions.partialClone',
@@ -467,8 +458,6 @@ class Git(Scm):
 
         if self.revision and not self._ref_exists(self.revision):
             refspec = self.revision + ":" + self.revision
-            if self.partial_clone:
-                command.insert(-3, '--filter=tree:0')
             cmd = self._get_scm_cmd() + ['fetch', 'origin',
                                          refspec]
             self.helpers.safe_run(

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -63,8 +63,7 @@ class Hg(Scm):
         if not self.is_sslverify_enabled():
             command += ['--insecure']
         wdir = os.path.abspath(os.path.join(self.clone_dir, os.pardir))
-        self.helpers.safe_run(command, wdir,
-                              interactive=sys.stdout.isatty())
+        self.run_and_hide(command, wdir)
 
     def update_cache(self):
         """Update sources via hg."""

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -314,7 +314,7 @@ class GitTests(GitHgTests, GitSvnTests):
         f_tasks = FakeTasks()
         git = Git(f_args, f_tasks)
 
-        p_tag = git._detect_parent_tag(f_args)
+        p_tag = git._detect_parent_tag()
         self.assertEqual(p_tag, '')
 
     def test_changesgenerate_unicode(self):


### PR DESCRIPTION
This patch makes sure that the `match_tag` parameter is used always when detecting the parent tag.

Without this patch if you use revision=@PARENT_TAG@ and set match-tag it may use the first tagged commit to package the code but use latest tag matching the match-tag pattern as `version`.