### PR TITLE
Allow specifying multiple versionrewrite-pattern/versionrewrite-replacement

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -43,6 +43,23 @@ def validate_extract_rename(extract_rename):
     return True
 
 
+def validate_versionrewrite(patterns, replacements):
+    # patterns and replacements are paired by index, so when more than one of
+    # either is given their counts must match
+    patterns_len = len(patterns or [])
+    replacements_len = len(replacements or [])
+
+    if (patterns_len > 1 or replacements_len > 1) and \
+            patterns_len != replacements_len:
+        print('--versionrewrite-pattern and --versionrewrite-replacement '
+              'must be specified the same number of times when more than one '
+              'is given (got %d pattern(s) and %d replacement(s))' %
+              (patterns_len, replacements_len))
+        return False
+
+    return True
+
+
 def check_locale(loc):
     try:
         aloc_tmp = subprocess.check_output(['locale', '-a'])
@@ -109,17 +126,21 @@ class Cli():
                                  'source using this format string. '
                                  'This parameter is used if the \'version\' '
                                  'parameter is not specified.')
-        parser.add_argument('--versionrewrite-pattern',
+        parser.add_argument('--versionrewrite-pattern', action='append',
                             help='Regex used to rewrite the version which is '
                                  'applied post versionformat. For example, to '
                                  'remove a tag prefix of "v" the regex '
                                  '"v(.*)" could be used. See the '
-                                 'versionrewrite-replacement parameter.')
-        parser.add_argument('--versionrewrite-replacement',
-                            default=r'\1',
+                                 'versionrewrite-replacement parameter. May '
+                                 'be specified multiple times. Patterns are '
+                                 'applied in order, each paired with the '
+                                 'matching versionrewrite-replacement.')
+        parser.add_argument('--versionrewrite-replacement', action='append',
                             help='Replacement applied to rewrite pattern. '
                                  'Typically backreferences are useful and as '
-                                 'such defaults to \\1.')
+                                 'such defaults to \\1. May be specified '
+                                 'multiple times. The Nth replacement is '
+                                 'paired with the Nth versionrewrite-pattern.')
         parser.add_argument('--versionprefix',
                             help='Specify a base version as prefix.')
         parser.add_argument('--parent-tag',
@@ -269,6 +290,11 @@ class Cli():
 
         if args.filename and "/" in args.filename:
             sys.exit('--filename must not specify a path')
+
+        if not validate_versionrewrite(args.versionrewrite_pattern,
+                                       args.versionrewrite_replacement):
+            sys.exit('--versionrewrite-pattern/--versionrewrite-replacement '
+                     'is not valid')
 
         # booleanize non-standard parameters
         args.changesgenerate      = bool(args.changesgenerate == 'enable')

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -316,8 +316,21 @@ class Tasks():
         if version == '_auto_' or self.args.versionformat:
             version = self.detect_version()
         if self.args.versionrewrite_pattern:
-            regex = re.compile(self.args.versionrewrite_pattern)
-            version = regex.sub(self.args.versionrewrite_replacement, version)
+            patterns = self.args.versionrewrite_pattern
+            if isinstance(patterns, str):
+                patterns = [patterns]
+            replacements = self.args.versionrewrite_replacement
+            if replacements is None:
+                replacements = []
+            elif isinstance(replacements, str):
+                replacements = [replacements]
+            for num, pattern in enumerate(patterns):
+                try:
+                    replacement = replacements[num]
+                except IndexError:
+                    replacement = r'\1'
+                regex = re.compile(pattern)
+                version = regex.sub(replacement, version)
         else:
             args = self.args.__dict__
             debian = args.get('use_obs_gbp', False)

--- a/tar_scm.service.in
+++ b/tar_scm.service.in
@@ -100,13 +100,16 @@
     <description>
       Regex used to rewrite the version which is applied post versionformat. For
       example, to remove a tag prefix of "v" the regex "v(.*)" could be used.
-      See the versionrewrite-replacement parameter.
+      See the versionrewrite-replacement parameter. Can be specified multiple
+      times, in which case the patterns are applied in order, each paired with
+      the versionrewrite-replacement given at the same position.
     </description>
   </parameter>
   <parameter name="versionrewrite-replacement">
     <description>
       Replacement applied to rewrite pattern. Typically backreferences are
-      useful and as such defaults to \1.
+      useful and as such defaults to \1. Can be specified multiple times. The
+      Nth replacement is paired with the Nth versionrewrite-pattern.
     </description>
   </parameter>
   <parameter name="versionprefix">

--- a/tests/gittests.py
+++ b/tests/gittests.py
@@ -250,6 +250,19 @@ class GitTests(GitHgTests, GitSvnTests):
                          "--versionformat", "@PARENT_TAG@")
         self.assertTarOnly(self.basename(version="2-test"))
 
+    def test_versionrewrite_multiple(self):
+        fix = self.fixtures
+        fix.create_commits(2)
+        fix.safe_run('tag v263-rc3')
+        self.tar_scm_std("--revision", 'v263-rc3',
+                         "--match-tag", 'v*',
+                         "--versionrewrite-pattern", r'(\d)-rc',  # noqa: W605,E501 pylint: disable=W1401
+                         "--versionrewrite-replacement", r'\1~rc',  # noqa: W605,E501 pylint: disable=W1401
+                         "--versionrewrite-pattern", r'v(.*)',  # noqa: W605,E501 pylint: disable=W1401
+                         "--versionrewrite-replacement", r'\1',  # noqa: W605,E501 pylint: disable=W1401
+                         "--versionformat", "@PARENT_TAG@")
+        self.assertTarOnly(self.basename(version="263~rc3"))
+
     def test_match_tag(self):
         fix = self.fixtures
         fix.create_commits(2)

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -209,6 +209,21 @@ version: 1.0
         ver     = tasks.get_version()
         self.assertEqual(ver, '0.0.1-stable')
 
+    def test_get_version_multi_rules(self):
+        '''Test get_version with multiple sequential versionrewrite'''
+        self.cli.versionrewrite_pattern     = [r'(\d)-rc', r'v(.*)']
+        self.cli.versionrewrite_replacement = [r'\1~rc', r'\1']
+        cases = {
+            'v263.999+30+gdeadbeef':     '263.999+30+gdeadbeef',
+            'v263.1.999+30+gdeadbeef':   '263.1.999+30+gdeadbeef',
+            'v263-rc3.999+30+gdeadbeef': '263~rc3.999+30+gdeadbeef',
+        }
+        for raw, expected in cases.items():
+            scm   = FakeSCM(raw)
+            tasks = TarSCM.Tasks(self.cli)
+            tasks.scm_object = scm
+            self.assertEqual(tasks.get_version(), expected)
+
     def test_process_list(self):
         self.cli.snapcraft = False
         tasks = TarSCM.Tasks(self.cli)

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -56,6 +56,35 @@ class UnitTestCases(unittest.TestCase):
             self.assertTrue(scm.clone_dir.endswith('/repo'))
             self.tasks.cleanup()
 
+    def test_versionrw_count_mismatch(self):
+        cli = TarSCM.Cli()
+        self.assertRaisesRegex(
+            SystemExit,
+            re.compile("--versionrewrite-pattern/--versionrewrite-replacement "
+                       "is not valid"),
+            cli.parse_args,
+            ['--outdir', '.',
+             '--versionrewrite-pattern', 'a',
+             '--versionrewrite-pattern', 'b',
+             '--versionrewrite-replacement', 'x'],
+        )
+
+    def test_versionrw_count_match(self):
+        cli = TarSCM.Cli()
+        cli.parse_args(['--outdir', '.',
+                        '--versionrewrite-pattern', 'a',
+                        '--versionrewrite-pattern', 'b',
+                        '--versionrewrite-replacement', 'x',
+                        '--versionrewrite-replacement', 'y'])
+        self.assertEqual(cli.versionrewrite_pattern, ['a', 'b'])
+        self.assertEqual(cli.versionrewrite_replacement, ['x', 'y'])
+
+    def test_versionrw_single_pattern(self):
+        cli = TarSCM.Cli()
+        cli.parse_args(['--outdir', '.',
+                        '--versionrewrite-pattern', 'a'])
+        self.assertEqual(cli.versionrewrite_pattern, ['a'])
+
     @patch('TarSCM.Helpers.safe_run')
     def test__git_log_cmd_with_args(self, safe_run_mock):
         scm     = Git(self.cli, self.tasks)


### PR DESCRIPTION
In most packaging versioning schemes, like deb, `'-'` has special meaning. `'~'` is typically used to separate RC versions, so that they sort LOWER than the final version and package upgrades work. But in git `'~'` is not a valid character in a git tag, so it cannot be part of a version, so typically `'-'` is used.

IOW, given a commonly used version scheme:

 v123-rc1
 v123

it is currently not possible to both remove the 'v' and optionally substitute the `'-'` with a `'~'`. But to get a valid packaging version from such tags, both need to happen. The issue is that in a single version replacement is not possible to have an optional substitution ('-' -> '~').

Allow specifying multiple versionrewrite-pattern and versionrewrite-replacement settings, and pair them in order (enforcing that the number is the same).

This allows having a first replacement to remove the 'v', and a second one to change `'-rc'` to `'~rc'` that will simply be skipped when the tag is not an rc.