### PR TITLE
Skip extracting globbed folders instead of just crashing

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -50,7 +50,10 @@ class BaseArchive():
                 if not r_src.startswith(repodir):
                     sys.exit("%s: tries to escape the repository" % src)
 
-                shutil.copy2(src, outdir)
+                if not os.path.isdir(src):
+                    shutil.copy2(src, outdir)
+                else:
+                    logging.warn("%s: Skipping directory" % src)
 
     def extract_rename_from_archive(self, repodir, tuples, outdir):
         """Extract and rename all files directly outside of the archive.


### PR DESCRIPTION
This PR attempts to make `--extract=*` skipping folders by default. Otherwise it will just crash and stall the entire service.

`osc` handles folders interactively by asking user for confirmation on commit. To get similar result, another scm service can be introduced to compress subfolder into specific archive format.