### PR TITLE
SCM workflow: fetch tags from upstream repo when building _branch_request

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -97,6 +97,7 @@ class Cli():
         self.maintainers_asc = None
         self.url = None
         self.revision = None
+        self.upstream_url = None
         self.user = None
         self.keyring_passphrase = None
         self.changesgenerate = False
@@ -266,6 +267,7 @@ class Cli():
     def verify_args(self, args):
         # basic argument validation
         # pylint: disable=too-many-branches
+        # pylint: disable=too-many-statements
         if not os.path.isdir(args.outdir):
             sys.exit("%s: No such directory" % args.outdir)
 

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -63,6 +63,8 @@ class Scm():
 
         # optional arguments
         self.revision       = args.revision
+        # used to fetch tags in SCM workflow builds
+        self.upstream_url   = getattr(args, 'upstream_url', None)
         if args.user and args.keyring_passphrase:
             if KEYRING_IMPORT_ERROR == 1:
                 raise SystemExit('Error while importing keyrings.alt.file but '
@@ -166,6 +168,10 @@ class Scm():
         # switch_to_revision
         self.switch_revision()
 
+        # fetch upstream repository tags when building branch request for SCM
+        # workflow
+        self.fetch_upstream_tags()
+
         # git specific: after switching to desired revision its necessary to
         # update
         # submodules since they depend on the actual version of the selected
@@ -180,6 +186,9 @@ class Scm():
         self.unlock_cache()
 
     def fetch_submodules(self):
+        """NOOP in other scm's than git"""
+
+    def fetch_upstream_tags(self):
         """NOOP in other scm's than git"""
 
     def fetch_lfs(self):

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -133,6 +133,17 @@ class Git(Scm):
         if lang_bak:
             os.environ['LANG'] = lang_bak
 
+    def fetch_upstream_tags(self):
+        """Fetch release tags from the upstream repository into the clone."""
+        if not self.upstream_url:
+            return
+
+        logging.debug("[fetch_upstream_tags] Fetching tags from '%s'",
+                      self.upstream_url)
+
+        command = self._get_scm_cmd() + ['fetch', '--tags', '--filter=tree:0', self.upstream_url]
+        self.helpers.safe_run(command, cwd=self.clone_dir)
+
     def fetch_upstream_scm(self):
         """SCM specific version of fetch_uptream for git."""
         self.auth_url()

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -168,14 +168,23 @@ class Tasks():
             dat = json.load(ofh)
         if dat.get('object_kind') == 'merge_request':
             # gitlab merge request
-            args.url = dat['project']['http_url']
-            rev = dat['object_attributes']['source']['default_branch']
-            args.revision = rev
+            head_url = dat['project']['http_url']
+            head_revision = \
+                dat['object_attributes']['source']['default_branch']
         elif dat.get('action') == 'opened':
             # github pull request
-            args.url = "https://github.com/"
-            args.url += dat['pull_request']['head']['repo']['full_name']
-            args.revision = dat['pull_request']['head']['sha']
+            head_url = "https://github.com/"
+            head_url += dat['pull_request']['head']['repo']['full_name']
+            head_revision = dat['pull_request']['head']['sha']
+        else:
+            return args
+
+        # keep the upstream repository for fetching its release tags as the
+        # request head fork may be missing them and they are needed for
+        # version detection via @PARENT_TAG@/@TAG_OFFSET@.
+        args.upstream_url = args.url
+        args.url = head_url
+        args.revision = head_revision
 
         return args
 


### PR DESCRIPTION
If the _service files uses the most recent git tag as the base version,
SCM workflow _branch_request builds will often fail as forks usually do
not carry the release tags, as Github doesn't automatically synchronize
them.

Fetch tags from the upstream repo (as recorded in the _service) when
a _branch_request is handled.