### PR TITLE
improve option sanitising revision/url

### DIFF
--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -6,6 +6,7 @@ import sys
 import locale
 import subprocess
 import logging
+import re
 
 
 def contains_dotdot(files):
@@ -318,5 +319,13 @@ class Cli():
         os.environ["LC_ALL"] = use_locale
         os.environ["LANG"] = use_locale
         os.environ["LANGUAGE"] = use_locale
+
+        # Filter for suspicious revision formats
+        # Allowed: `v1.1-2`
+        # Not Allowed:
+        #          `-1.1.2`
+        #          `1.1 2`
+        if args.revision and re.search(r'\s', args.revision):
+            raise SystemExit(f"option revision ({args.revision}) contains forbidden characters")
 
         return args

--- a/TarSCM/scm/base.py
+++ b/TarSCM/scm/base.py
@@ -9,6 +9,8 @@ import time
 import subprocess
 import glob
 
+from pathlib import Path
+
 from TarSCM.helpers import Helpers
 from TarSCM.changes import Changes
 from TarSCM.config import Config
@@ -403,7 +405,7 @@ class Scm():
         self.cleanup()
 
     def check_url(self):
-        return True
+        pass
 
     def run_and_hide(self, command, wdir, cleanup_dirs=[]):
         try:
@@ -416,6 +418,10 @@ class Scm():
             raise SystemExit(exc)
 
     def _prepare_gpg_settings(self):
+        infile = Path(self.args.maintainers_asc)
+        if not infile.is_file():
+            raise SystemExit(f"File {infile} does not exist.")
+
         logging.debug("preparing gpg settings")
         self._backup_gnupghome = os.getenv('GNUPGHOME')
         gpgdir = tempfile.mkdtemp()

--- a/TarSCM/scm/bzr.py
+++ b/TarSCM/scm/bzr.py
@@ -3,6 +3,7 @@ import re
 import os
 import dateutil.parser
 from TarSCM.scm.base import Scm
+from TarSCM.exceptions import OptionsError
 
 
 class Bzr(Scm):
@@ -71,5 +72,4 @@ class Bzr(Scm):
     def check_url(self):
         """check if url is a remote url"""
         if not re.match("^((a?ftp|bzr|https?)://|lp:)", self.url):
-            return False
-        return True
+            raise OptionsError(f"URL does not match allowed scheme: {self.url}")

--- a/TarSCM/scm/git.py
+++ b/TarSCM/scm/git.py
@@ -5,7 +5,7 @@ import sys
 import shutil
 
 from TarSCM.scm.base import Scm
-from TarSCM.exceptions import GitError
+from TarSCM.exceptions import GitError, OptionsError
 
 
 def search_tags(comment, limit=None):
@@ -489,19 +489,13 @@ class Git(Scm):
     def check_url(self):
         """check if url is a remote url"""
 
-        # no local path allowed
-        if re.match('^file:', self.url):
-            return False
+        if re.findall(r"\s", self.url):
+            raise OptionsError(f"URL contains space characters: {self.url}")
 
-        if '://' in self.url:
-            return bool(re.match("^(https?|ftps?|git|ssh)://", self.url))
+        pat = r"^(https?|ftps?|git|ssh)://"
+        if not re.match(pat, self.url):
+            raise OptionsError(f"Invalid url scheme ({pat}): {self.url}")
 
-        # e.g. user@host.xy:path/to/repo
-        if re.match('^[^/]+:', self.url):
-            return True
-
-        # Deny by default, might be local path
-        return False
 
     def find_latest_signed_commit(self, commit):
         if not commit:

--- a/TarSCM/scm/hg.py
+++ b/TarSCM/scm/hg.py
@@ -5,6 +5,7 @@ import tempfile
 import shutil
 import logging
 from TarSCM.scm.base import Scm
+from TarSCM.exceptions import OptionsError
 
 
 class Hg(Scm):
@@ -49,7 +50,8 @@ class Hg(Scm):
         if self.revision is None:
             self.revision = 'tip'
 
-        cmd = self._get_scm_cmd() + ['update', self.revision]
+        # prevent option injection by adding `--`
+        cmd = self._get_scm_cmd() + ['update', '--', self.revision]
         rcode, _ = self.helpers.run_cmd(cmd,
                                         cwd=self.clone_dir,
                                         interactive=sys.stdout.isatty())
@@ -142,5 +144,6 @@ class Hg(Scm):
     def check_url(self):
         """check if url is a remote url"""
         if not re.match("^https?://", self.url):
-            return False
-        return True
+            raise OptionsError(f"Invalid url scheme (try http/https): {self.url}")
+        if re.findall(r"\s", self.url):
+            raise OptionsError(f"Found space character in url: {self.url}")

--- a/TarSCM/scm/svn.py
+++ b/TarSCM/scm/svn.py
@@ -9,6 +9,7 @@ import shutil
 import dateutil.parser
 
 from TarSCM.scm.base import Scm
+from TarSCM.exceptions import OptionsError
 
 ENCODING_RE = re.compile(r".*("
                          "Can't convert string from '.*' to native encoding:"
@@ -239,5 +240,4 @@ class Svn(Scm):
     def check_url(self):
         """check if url is a remote url"""
         if not re.match("^(https?|svn)://", self.url):
-            return False
-        return True
+            raise OptionsError(f"Invalid url scheme (valid http/https/svn): {self.url}")

--- a/TarSCM/tasks.py
+++ b/TarSCM/tasks.py
@@ -212,8 +212,8 @@ class Tasks():
         self.scm_object = scm_object   = scm_class(args, self)
 
         tmode = bool(os.getenv('TAR_SCM_TESTMODE'))
-        if not tmode and not scm_object.check_url():
-            sys.exit("--url does not match remote repository")
+        if not tmode:
+            scm_object.check_url()
 
         try:
             scm_object.check_scm()

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+
+import unittest
+import re
+import argparse
+
+from tar_scm import TarSCM
+
+
+class CliTestCases(unittest.TestCase):
+    def setUp(self):
+        self.cli = TarSCM.Cli()
+
+    def test_parse_args_valid_revision(self):
+
+        valid_rev = ['1.2.3', 'v1.2.3', '1.2-3', '@PARENT_TAG@']
+        for rev in valid_rev:
+            self.cli.parse_args([
+                '--outdir', '.',
+                '--scm', 'git',
+                '--revision', rev
+            ])
+
+    def test_parse_args_invalid_revision(self):
+        for rev in ['1.2.3 --config', '1.2 3']:
+            with self.assertRaisesRegex(SystemExit, r"option revision \(.*\) contains forbidden characters"):
+                self.cli.parse_args([
+                    '--outdir', '.',
+                    '--scm', 'git',
+                    '--revision', rev
+                ])
+
+        for rev in ['1.2.3 --config', '-p123', '1.2 -p']:
+            with self.assertRaisesRegex(SystemExit, r"2"):
+                self.cli.parse_args([
+                    '--outdir', '.',
+                    '--scm', 'git',
+                    '--revision', rev
+                ])

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,6 +21,7 @@ from tests.unittestcases import UnitTestCases
 from tests.tasks import TasksTestCases
 from tests.scm import SCMBaseTestCases
 from tests.tartests import TarTestCases
+from tests.cli import CliTestCases
 from tests.archiveobscpiotestcases import ArchiveOBSCpioTestCases
 
 
@@ -43,7 +44,8 @@ def prepare_testclasses():
         SCMBaseTestCases,
         GitTests,
         SvnTests,
-        TarTestCases
+        TarTestCases,
+        CliTestCases
     ]
 
     # quite ugly to remove them here

--- a/tests/unittestcases.py
+++ b/tests/unittestcases.py
@@ -23,6 +23,7 @@ from TarSCM.scm.git import Git
 from TarSCM.scm.svn import Svn
 from TarSCM.scm.hg  import Hg
 from TarSCM.scm.bzr import Bzr
+from TarSCM.exceptions import OptionsError
 
 
 # pylint: disable=duplicate-code
@@ -248,7 +249,7 @@ class UnitTestCases(unittest.TestCase):
         for tca in tc_arr:
             for url in tca['urls']:
                 tca['obj'].url = url
-                self.assertTrue(tca['obj'].check_url())
+                tca['obj'].check_url()
 
     def test_check_url_invalid(self):
         invalid = [
@@ -265,6 +266,7 @@ class UnitTestCases(unittest.TestCase):
             '/lala/nana',
             '/tmp/user@example.com:my/local/path'
             '/tmp/example.com:my/local/path'
+            'local/relative/path'
         ]
 
         scms = [
@@ -278,7 +280,11 @@ class UnitTestCases(unittest.TestCase):
             for url in invalid:
                 print("%r %s" % (scm, url))
                 scm.url = url
-                self.assertFalse(scm.check_url())
+                self.assertRaisesRegex(
+                    OptionsError,
+                    re.compile(r"Invalid url scheme .*"),
+                    scm.check_url()
+                )
 
     def test_scm_tar_invalid_params(self):
         tc_name    = inspect.stack()[0][3]


### PR DESCRIPTION
* Advanced sanity checks for revision
  * Improved `hg update` call by adding `--` before `revision`
* Pre-check existence of maintainers-asc
* Enforce remote urls for git repositories
* Improved error messages for url sanity checks
* Adapted test cases for `check_url`
* Implemented test cases for option `--revision`

Fixes: boo#1269546
Fixes: CVE-2026-56004