### PR TITLE
Add option to delete source .obscpio archive in tar service

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -263,6 +263,12 @@ class Tar(BaseArchive):
 
         self.archivefile    = tar.name
 
+        if args.delete:
+            obscpio_file = os.path.join(outdir, dstname + '.obscpio')
+            if os.path.exists(obscpio_file):
+                logging.debug("Deleting source archive '%s'", obscpio_file)
+                os.remove(obscpio_file)
+
         os.chdir(cwd)
 
 

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -197,6 +197,9 @@ class Cli():
                             choices=['yes', 'no'], default='no',
                             help='Package the meta data of SCM to allow the '
                                  'user or OBS to update after un-tar')
+        parser.add_argument('--delete', choices=['yes', 'no'], default='no',
+                            help='Delete the source .obscpio archive after successful '
+                                 'creation of the tarball')
         parser.add_argument('--outdir', required=True,
                             help='osc service parameter for internal use only '
                                  '(determines where generated files go before '
@@ -279,6 +282,7 @@ class Cli():
         args.use_obs_gbp          = bool(args.use_obs_gbp)
         args.latest_signed_commit = bool(args.latest_signed_commit)
         args.latest_signed_tag    = bool(args.latest_signed_tag)
+        args.delete               = bool(args.delete == 'yes')
         t_gbp_dch_release_u = bool(args.gbp_dch_release_update != 'disable')
         args.gbp_dch_release_update = t_gbp_dch_release_u
 

--- a/TarSCM/cli.py
+++ b/TarSCM/cli.py
@@ -245,6 +245,24 @@ class Cli():
 
         self.verify_args(parser.parse_args(options))
 
+    def configure_locale(self, args):
+        if args.locale:
+            use_locale = args.locale
+        elif args.encoding:
+            use_locale = check_locale([
+                "en_US.%s" % args.encoding,
+                "C.%s" % args.encoding])
+        else:
+            use_locale = check_locale(["en_US.utf8", 'C.utf8'])
+
+        logging.debug("Using locale: %s", use_locale)
+
+        locale.setlocale(locale.LC_ALL, use_locale)
+
+        os.environ["LC_ALL"] = use_locale
+        os.environ["LANG"] = use_locale
+        os.environ["LANGUAGE"] = use_locale
+
     def verify_args(self, args):
         # basic argument validation
         # pylint: disable=too-many-branches
@@ -307,22 +325,7 @@ class Cli():
         for attr in args.__dict__.keys():
             self.__dict__[attr] = args.__dict__[attr]
 
-        if args.locale:
-            use_locale = args.locale
-        elif args.encoding:
-            use_locale = check_locale([
-                "en_US.%s" % args.encoding,
-                "C.%s" % args.encoding])
-        else:
-            use_locale = check_locale(["en_US.utf8", 'C.utf8'])
-
-        logging.debug("Using locale: %s", use_locale)
-
-        locale.setlocale(locale.LC_ALL, use_locale)
-
-        os.environ["LC_ALL"] = use_locale
-        os.environ["LANG"] = use_locale
-        os.environ["LANGUAGE"] = use_locale
+        self.configure_locale(args)
 
         # Filter for suspicious revision formats
         # Allowed: `v1.1-2`

--- a/tests/tartests.py
+++ b/tests/tartests.py
@@ -78,3 +78,92 @@ class TarTestCases(TestEnvironment, TestAssertions):
         files.sort()
         expected = ['pkgname1-0.1.1-0.1.1.tar', 'pkgname2-0.1.2-0.1.2.tar']
         self.assertEqual(files, expected)
+
+    def test_tar_delete_obscpio(self):
+        """Test that .obscpio is deleted when --delete is set."""
+        wdir = self.pkgdir
+        # Create a dummy .obscpio file in the outdir
+        # Since outdir is created fresh in tar_scm(), we need to be careful.
+        # Actually, the service usually runs: obs_scm -> tar.
+        # obs_scm creates the .obscpio in outdir.
+
+        # We can simulate this by creating the .obscpio file in the outdir
+        # before calling tar_scm, but tar_scm calls mkfreshdir(self.outdir).
+        # So we should probably use a different approach or modify testenv.
+
+        # Let's try to use a custom outdir or override mkfreshdir.
+        # Alternatively, we can just test the Tar.create_archive method directly.
+
+        from TarSCM.archive import Tar
+        from tests.fake_classes import FakeCli
+        import shutil
+
+        # Setup a temporary environment
+        import tempfile
+        tmp = tempfile.mkdtemp()
+        try:
+            outdir = os.path.join(tmp, 'out')
+            os.mkdir(outdir)
+
+            # Mock SCM object
+            class MockSCM:
+                def __init__(self):
+                    self.arch_dir = os.path.join(tmp, 'arch')
+                    os.mkdir(self.arch_dir)
+                    self.clone_dir = self.arch_dir
+                def get_timestamp(self, *args): return 123456789
+
+            scm_obj = MockSCM()
+
+            # Case 1: delete='yes'
+            cli_yes = FakeCli()
+            cli_yes.outdir = outdir
+            cli_yes.delete = True
+            cli_yes.extension = 'tar'
+            cli_yes.include = []
+            cli_yes.exclude = []
+            cli_yes.include_re = None
+            cli_yes.exclude_re = None
+            cli_yes.package_meta = 'no'
+
+            # Create a dummy .obscpio file
+            obscpio_path = os.path.join(outdir, 'testpkg-1.0.obscpio')
+            with open(obscpio_path, 'w') as f:
+                f.write('dummy content')
+
+            tar_arch = Tar()
+            tar_arch.create_archive(scm_obj, basename='testpkg', dstname='testpkg-1.0', version='1.0', cli=cli_yes)
+
+            self.assertTrue(os.path.exists(os.path.join(outdir, 'testpkg-1.0.tar')))
+            self.assertFalse(os.path.exists(obscpio_path), "The .obscpio file should have been deleted")
+
+            # Case 2: delete='no'
+            # Reset environment
+            shutil.rmtree(tmp)
+            tmp = tempfile.mkdtemp()
+            outdir = os.path.join(tmp, 'out')
+            os.mkdir(outdir)
+            scm_obj = MockSCM()
+
+            cli_no = FakeCli()
+            cli_no.outdir = outdir
+            cli_no.delete = False
+            cli_no.extension = 'tar'
+            cli_no.include = []
+            cli_no.exclude = []
+            cli_no.include_re = None
+            cli_no.exclude_re = None
+            cli_no.package_meta = 'no'
+
+            obscpio_path = os.path.join(outdir, 'testpkg-1.0.obscpio')
+            with open(obscpio_path, 'w') as f:
+                f.write('dummy content')
+
+            tar_arch = Tar()
+            tar_arch.create_archive(scm_obj, basename='testpkg', dstname='testpkg-1.0', version='1.0', cli=cli_no)
+
+            self.assertTrue(os.path.exists(os.path.join(outdir, 'testpkg-1.0.tar')))
+            self.assertTrue(os.path.exists(obscpio_path), "The .obscpio file should NOT have been deleted")
+
+        finally:
+            shutil.rmtree(tmp)


### PR DESCRIPTION
Introduce a 'delete' parameter for the tar service that allows removing the source `.obscpio` archive after a tarball has been successfully created. This prevents duplicate archives when using the `obs_scm`, `tar`, and `recompress` services in combination.

- Add `--delete` CLI argument (defaults to 'no' for compatibility).
- Implement deletion logic in `Tar.create_archive`.
- Add unit tests in tests/tartests.py to verify deletion behaviour.

Fixes: https://github.com/openSUSE/obs-service-tar_scm/issues/515